### PR TITLE
Add macOS 12 runner for amd64 support on macOS

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Our current runner matrix is missing a macOS amd64 only platform. The `macos-latest` is running on an M1 machine which might run on arm64 architecture. Adding `macos-12` should help improve our tests coverage.

The list of runners and images can be found on https://github.com/actions/runner-images