### PR TITLE
Add linter step to github actions

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -25,3 +25,5 @@ jobs:
         run: pytest tests
       - name: Run type checker
         run: python -m mypy --config-file mypy.ini -p staking_deposit
+      - name: Run linter
+        run: flake8 --config=flake8.ini ./staking_deposit ./tests

--- a/staking_deposit/credentials.py
+++ b/staking_deposit/credentials.py
@@ -115,7 +115,7 @@ class Credential:
     def deposit_message(self) -> DepositMessage:
         if not MIN_DEPOSIT_AMOUNT <= self.amount <= MAX_DEPOSIT_AMOUNT:
             raise ValidationError(f"{self.amount / ETH2GWEI} ETH deposits are not within the bounds of this cli.")
-        return DepositMessage( # type: ignore[no-untyped-call]
+        return DepositMessage(  # type: ignore[no-untyped-call]
             pubkey=self.signing_pk,
             withdrawal_credentials=self.withdrawal_credentials,
             amount=self.amount,
@@ -125,8 +125,8 @@ class Credential:
     def signed_deposit(self) -> DepositData:
         domain = compute_deposit_domain(fork_version=self.chain_setting.GENESIS_FORK_VERSION)
         signing_root = compute_signing_root(self.deposit_message, domain)
-        signed_deposit = DepositData( # type: ignore[no-untyped-call]
-            **self.deposit_message.as_dict(), # type: ignore[no-untyped-call]
+        signed_deposit = DepositData(  # type: ignore[no-untyped-call]
+            **self.deposit_message.as_dict(),  # type: ignore[no-untyped-call]
             signature=bls.Sign(self.signing_sk, signing_root)
         )
         return signed_deposit
@@ -138,7 +138,7 @@ class Credential:
         the information needed to verify and process the deposit.
         """
         signed_deposit_datum = self.signed_deposit
-        datum_dict = signed_deposit_datum.as_dict() # type: ignore[no-untyped-call]
+        datum_dict = signed_deposit_datum.as_dict()  # type: ignore[no-untyped-call]
         datum_dict.update({'deposit_message_root': self.deposit_message.hash_tree_root})
         datum_dict.update({'deposit_data_root': signed_deposit_datum.hash_tree_root})
         datum_dict.update({'fork_version': self.chain_setting.GENESIS_FORK_VERSION})
@@ -165,7 +165,7 @@ class Credential:
         if self.eth1_withdrawal_address is None:
             raise ValueError("The execution address should NOT be empty.")
 
-        message = BLSToExecutionChange( # type: ignore[no-untyped-call]
+        message = BLSToExecutionChange(  # type: ignore[no-untyped-call]
             validator_index=validator_index,
             from_bls_pubkey=self.withdrawal_pk,
             to_execution_address=self.eth1_withdrawal_address,
@@ -177,7 +177,7 @@ class Credential:
         signing_root = compute_signing_root(message, domain)
         signature = bls.Sign(self.withdrawal_sk, signing_root)
 
-        return SignedBLSToExecutionChange( # type: ignore[no-untyped-call]
+        return SignedBLSToExecutionChange(  # type: ignore[no-untyped-call]
             message=message,
             signature=signature,
         )
@@ -186,12 +186,16 @@ class Credential:
         result_dict: Dict[str, Any] = {}
         signed_bls_to_execution_change = self.get_bls_to_execution_change(validator_index)
         message = {
-            'validator_index': str(signed_bls_to_execution_change.message.validator_index), # type: ignore[attr-defined]
-            'from_bls_pubkey': '0x' + signed_bls_to_execution_change.message.from_bls_pubkey.hex(), # type: ignore[attr-defined]
-            'to_execution_address': '0x' + signed_bls_to_execution_change.message.to_execution_address.hex(), # type: ignore[attr-defined]
+            'validator_index':
+                str(signed_bls_to_execution_change.message.validator_index),  # type: ignore[attr-defined]
+            'from_bls_pubkey': '0x' +
+                signed_bls_to_execution_change.message.from_bls_pubkey.hex(),  # type: ignore[attr-defined]
+            'to_execution_address': '0x' +
+                signed_bls_to_execution_change.message.to_execution_address.hex(),  # type: ignore[attr-defined]
         }
         result_dict.update({'message': message})
-        result_dict.update({'signature': '0x' + signed_bls_to_execution_change.signature.hex()}) # type: ignore[attr-defined]
+        result_dict.update({'signature': '0x' +
+                            signed_bls_to_execution_change.signature.hex()})  # type: ignore[attr-defined]
 
         # metadata
         metadata: Dict[str, Any] = {

--- a/staking_deposit/utils/ssz.py
+++ b/staking_deposit/utils/ssz.py
@@ -39,7 +39,7 @@ def compute_fork_data_root(current_version: bytes, genesis_validators_root: byte
     """
     if len(current_version) != 4:
         raise ValueError(f"Fork version should be in 4 bytes. Got {len(current_version)}.")
-    return ForkData( # type: ignore[no-untyped-call]
+    return ForkData(  # type: ignore[no-untyped-call]
         current_version=current_version,
         genesis_validators_root=genesis_validators_root,
     ).hash_tree_root
@@ -83,7 +83,7 @@ def compute_signing_root(ssz_object: Serializable, domain: bytes) -> bytes:
     """
     if len(domain) != 32:
         raise ValueError(f"Domain should be in 32 bytes. Got {len(domain)}.")
-    domain_wrapped_object = SigningData( # type: ignore[no-untyped-call]
+    domain_wrapped_object = SigningData(  # type: ignore[no-untyped-call]
         object_root=ssz_object.hash_tree_root,
         domain=domain,
     )

--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -89,14 +89,18 @@ def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential) 
         return False
 
     # Verify deposit signature && pubkey
-    deposit_message = DepositMessage(pubkey=pubkey, withdrawal_credentials=withdrawal_credentials, amount=amount) # type: ignore[no-untyped-call]
+    deposit_message = DepositMessage(  # type: ignore[no-untyped-call]
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        amount=amount
+    )
     domain = compute_deposit_domain(fork_version)
     signing_root = compute_signing_root(deposit_message, domain)
     if not bls.Verify(pubkey, signing_root, signature):
         return False
 
     # Verify Deposit Root
-    signed_deposit = DepositData( # type: ignore[no-untyped-call]
+    signed_deposit = DepositData(  # type: ignore[no-untyped-call]
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
         amount=amount,
@@ -189,7 +193,7 @@ def validate_bls_to_execution_change(btec_dict: Dict[str, Any],
     if genesis_validators_root != chain_setting.GENESIS_VALIDATORS_ROOT:
         return False
 
-    message = BLSToExecutionChange( # type: ignore[no-untyped-call]
+    message = BLSToExecutionChange(  # type: ignore[no-untyped-call]
         validator_index=validator_index,
         from_bls_pubkey=from_bls_pubkey,
         to_execution_address=to_execution_address,


### PR DESCRIPTION
Using the existing `flake8.ini` file.

`flake8 --config=flake8.ini ./staking_deposit ./tests` 

Looks like this was the setup for tox run by circleci