### PR TITLE
Exclude failing matrix job for macos-latest and Python 3.9

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Fixes #21 .

It seems like Github removed some support for older Python version on their runner. This will exclude it and fix our current failing runs.