### PR TITLE
Withdrawal address prompt

### DIFF
--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -70,6 +70,7 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
                     lambda: load_text(['chain', 'prompt'], func='generate_keys_arguments_decorator'),
                     list(ALL_CHAINS.keys())
                 ),
+                default=MAINNET,
             ),
             default=MAINNET,
             help=lambda: load_text(['chain', 'help'], func='generate_keys_arguments_decorator'),
@@ -99,10 +100,12 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
                 lambda: load_text(['arg_execution_address', 'prompt'], func='generate_keys_arguments_decorator'),
                 lambda: load_text(['arg_execution_address', 'confirm'], func='generate_keys_arguments_decorator'),
                 lambda: load_text(['arg_execution_address', 'mismatch'], func='generate_keys_arguments_decorator'),
+                default="",
             ),
-            default=None,
+            default="",
             help=lambda: load_text(['arg_execution_address', 'help'], func='generate_keys_arguments_decorator'),
             param_decls=['--execution_address', '--eth1_withdrawal_address'],
+            prompt=lambda: load_text(['arg_execution_address', 'prompt'], func='generate_keys_arguments_decorator'),
         ),
     ]
     for decorator in reversed(decorators):

--- a/staking_deposit/cli/new_mnemonic.py
+++ b/staking_deposit/cli/new_mnemonic.py
@@ -38,6 +38,7 @@ languages = get_first_options(MNEMONIC_LANG_OPTIONS)
     callback=captive_prompt_callback(
         lambda mnemonic_language: fuzzy_reverse_dict_lookup(mnemonic_language, MNEMONIC_LANG_OPTIONS),
         choice_prompt_func(lambda: load_text(['arg_mnemonic_language', 'prompt'], func='new_mnemonic'), languages),
+        default=lambda: load_text(['arg_mnemonic_language', 'default'], func='new_mnemonic'),
     ),
     default=lambda: load_text(['arg_mnemonic_language', 'default'], func='new_mnemonic'),
     help=lambda: load_text(['arg_mnemonic_language', 'help'], func='new_mnemonic'),

--- a/staking_deposit/deposit.py
+++ b/staking_deposit/deposit.py
@@ -34,6 +34,7 @@ def check_python_version() -> None:
     callback=captive_prompt_callback(
         lambda language: fuzzy_reverse_dict_lookup(language, INTL_LANG_OPTIONS),
         choice_prompt_func(lambda: 'Please choose your language', get_first_options(INTL_LANG_OPTIONS)),
+        default='English',
     ),
     default='English',
     help='The language you wish to use the CLI in.',

--- a/staking_deposit/intl/en/cli/generate_keys.json
+++ b/staking_deposit/intl/en/cli/generate_keys.json
@@ -19,7 +19,7 @@
         },
         "arg_execution_address": {
             "help": "The 20-byte (Eth1) execution address that will be used in withdrawal",
-            "prompt": "Please enter the 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
+            "prompt": "Please enter the optional 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
             "confirm": "Repeat your execution address for confirmation.",
             "mismatch": "Error: the two entered values do not match. Please type again."
         }

--- a/staking_deposit/utils/click.py
+++ b/staking_deposit/utils/click.py
@@ -85,6 +85,7 @@ def captive_prompt_callback(
     confirmation_prompt: Optional[Callable[[], str]]=None,
     confirmation_mismatch_msg: Callable[[], str]=lambda: '',
     hide_input: bool=False,
+    default: Any=None,
 ) -> Callable[[click.Context, str, str], Any]:
     '''
     Traps the user in a prompt until the value chosen is acceptable
@@ -109,7 +110,7 @@ def captive_prompt_callback(
                 return processed_input
             except ValidationError as e:
                 click.echo('\n[Error] ' + str(e))
-                user_input = click.prompt(prompt(), hide_input=hide_input)
+                user_input = click.prompt(prompt(), hide_input=hide_input, default=default)
     return callback
 
 

--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -129,7 +129,7 @@ def validate_int_range(num: Any, low: int, high: int) -> int:
 
 
 def validate_eth1_withdrawal_address(cts: click.Context, param: Any, address: str) -> HexAddress:
-    if address is None:
+    if address in ("", None):
         return None
     if not is_hex_address(address):
         raise ValidationError(load_text(['err_invalid_ECDSA_hex_addr']))

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -195,6 +195,7 @@ async def test_script() -> None:
         '--validator_start_index', '1',
         '--chain', 'mainnet',
         '--keystore_password', 'MyPassword',
+        '--eth1_withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
     proc = await asyncio.create_subprocess_shell(
@@ -242,6 +243,7 @@ async def test_script_abbreviated_mnemonic() -> None:
         '--validator_start_index', '1',
         '--chain', 'mainnet',
         '--keystore_password', 'MyPassword',
+        '--eth1_withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
     proc = await asyncio.create_subprocess_shell(

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -28,6 +28,7 @@ def test_existing_mnemonic_bls_withdrawal() -> None:
     arguments = [
         '--language', 'english',
         'existing-mnemonic',
+        '--eth1_withdrawal_address', '',
         '--folder', my_folder_path,
         '--mnemonic-password', 'TREZOR',
     ]
@@ -65,16 +66,14 @@ def test_existing_mnemonic_eth1_address_withdrawal() -> None:
     eth1_withdrawal_address = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
     inputs = [
         'TREZOR',
-        eth1_withdrawal_address,
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-        '2', '2', '5', 'mainnet', 'MyPassword', 'MyPassword']
+        '2', '2', '5', 'mainnet', 'MyPassword', 'MyPassword', eth1_withdrawal_address, eth1_withdrawal_address]
     data = '\n'.join(inputs)
     arguments = [
         '--language', 'english',
         'existing-mnemonic',
         '--folder', my_folder_path,
         '--mnemonic-password', 'TREZOR',
-        '--eth1_withdrawal_address', eth1_withdrawal_address,
     ]
     result = runner.invoke(cli, arguments, input=data)
 
@@ -123,9 +122,9 @@ def test_existing_mnemonic_eth1_address_withdrawal_bad_checksum() -> None:
 
     inputs = [
         'TREZOR',
-        correct_eth1_withdrawal_address, correct_eth1_withdrawal_address,
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-        '2', '2', '5', 'mainnet', 'MyPassword', 'MyPassword'
+        '2', '2', '5', 'mainnet', 'MyPassword', 'MyPassword',
+        wrong_eth1_withdrawal_address, correct_eth1_withdrawal_address, correct_eth1_withdrawal_address
     ]
     data = '\n'.join(inputs)
     arguments = [
@@ -133,7 +132,6 @@ def test_existing_mnemonic_eth1_address_withdrawal_bad_checksum() -> None:
         'existing-mnemonic',
         '--folder', my_folder_path,
         '--mnemonic-password', 'TREZOR',
-        '--eth1_withdrawal_address', wrong_eth1_withdrawal_address,
     ]
     result = runner.invoke(cli, arguments, input=data)
 

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -79,14 +79,13 @@ def test_new_mnemonic_eth1_address_withdrawal(monkeypatch) -> None:
 
     runner = CliRunner()
     eth1_withdrawal_address = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
-    inputs = [eth1_withdrawal_address, 'english', '1', 'mainnet', 'MyPassword', 'MyPassword',
+    inputs = ['english', '1', 'mainnet', 'MyPassword', 'MyPassword', eth1_withdrawal_address, eth1_withdrawal_address,
               'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about']
     data = '\n'.join(inputs)
     arguments = [
         '--language', 'english',
         'new-mnemonic',
         '--folder', my_folder_path,
-        '--eth1_withdrawal_address', eth1_withdrawal_address,
     ]
     result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0
@@ -139,15 +138,14 @@ def test_new_mnemonic_eth1_address_withdrawal_bad_checksum(monkeypatch) -> None:
     wrong_eth1_withdrawal_address = '0x00000000219ab540356cBB839Cbe05303d7705FA'
     correct_eth1_withdrawal_address = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
 
-    inputs = [correct_eth1_withdrawal_address, correct_eth1_withdrawal_address,
-              'english', '1', 'mainnet', 'MyPassword', 'MyPassword',
+    inputs = ['english', '1', 'mainnet', 'MyPassword', 'MyPassword',
+              wrong_eth1_withdrawal_address, correct_eth1_withdrawal_address, correct_eth1_withdrawal_address,
               'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about']
     data = '\n'.join(inputs)
     arguments = [
         '--language', 'english',
         'new-mnemonic',
         '--folder', my_folder_path,
-        '--eth1_withdrawal_address', wrong_eth1_withdrawal_address,
     ]
     result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -38,8 +38,8 @@ def test_new_mnemonic_bls_withdrawal(monkeypatch) -> None:
     data = '\n'.join(inputs)
     arguments = [
         'new-mnemonic',
+        '--eth1_withdrawal_address', '',
         '--folder', my_folder_path,
-        '--eth1_withdrawal_address=""',
     ]
     result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -36,7 +36,12 @@ def test_new_mnemonic_bls_withdrawal(monkeypatch) -> None:
     inputs = ['english', 'english', '1', 'mainnet', 'MyPassword', 'MyPassword',
               'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about']
     data = '\n'.join(inputs)
-    result = runner.invoke(cli, ['new-mnemonic', '--folder', my_folder_path], input=data)
+    arguments = [
+        'new-mnemonic',
+        '--folder', my_folder_path,
+        '--eth1_withdrawal_address=""',
+    ]
+    result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0
 
     # Check files
@@ -291,6 +296,7 @@ async def test_script_bls_withdrawal() -> None:
         '--mnemonic_language', 'english',
         '--chain', 'mainnet',
         '--keystore_password', 'MyPassword',
+        '--eth1_withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
     proc = await asyncio.create_subprocess_shell(
@@ -375,6 +381,7 @@ async def test_script_abbreviated_mnemonic() -> None:
         '--mnemonic_language', 'english',
         '--chain', 'mainnet',
         '--keystore_password', 'MyPassword',
+        '--eth1_withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
     proc = await asyncio.create_subprocess_shell(

--- a/tests/test_cli/test_regeneration.py
+++ b/tests/test_cli/test_regeneration.py
@@ -35,7 +35,12 @@ def test_regeneration(monkeypatch) -> None:
     my_password = "MyPassword"
     inputs = ['english', 'english', '2', 'mainnet', my_password, my_password, mock_mnemonic]
     data = '\n'.join(inputs)
-    result = runner.invoke(cli, ['new-mnemonic', '--folder', folder_path_1], input=data)
+    arguments = [
+        'new-mnemonic',
+        '--folder', folder_path_1,
+        '--eth1_withdrawal_address=""',
+    ]
+    result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0
 
     # Check files
@@ -60,7 +65,11 @@ def test_regeneration(monkeypatch) -> None:
         mock_mnemonic,
         '1', '1', '2', 'mainnet', 'MyPassword', 'MyPassword']
     data = '\n'.join(inputs)
-    arguments = ['existing-mnemonic', '--folder', folder_path_2]
+    arguments = [
+        'existing-mnemonic',
+        '--folder', folder_path_2,
+        '--eth1_withdrawal_address=""',
+    ]
     result = runner.invoke(cli, arguments, input=data)
 
     assert result.exit_code == 0

--- a/tests/test_cli/test_regeneration.py
+++ b/tests/test_cli/test_regeneration.py
@@ -37,8 +37,8 @@ def test_regeneration(monkeypatch) -> None:
     data = '\n'.join(inputs)
     arguments = [
         'new-mnemonic',
+        '--eth1_withdrawal_address', '',
         '--folder', folder_path_1,
-        '--eth1_withdrawal_address=""',
     ]
     result = runner.invoke(cli, arguments, input=data)
     assert result.exit_code == 0
@@ -67,8 +67,8 @@ def test_regeneration(monkeypatch) -> None:
     data = '\n'.join(inputs)
     arguments = [
         'existing-mnemonic',
+        '--eth1_withdrawal_address', '',
         '--folder', folder_path_2,
-        '--eth1_withdrawal_address=""',
     ]
     result = runner.invoke(cli, arguments, input=data)
 


### PR DESCRIPTION
Adding a prompt for withdrawal address when executing key generation.  

There are a few changes of note:
- I have added a `default` param for the captive prompt. I simply don't see why not.
- I am not confirming selection if the user provides an empty value for the withdrawal address but we can add it if necessary
- `closest_match` in `intl.py` creates some pretty weird UX scenarios especially during language selection. As an example, if you provide `1234` as the option for language, it will chose `12`. My assumption this is used to avoid non-standard character match issues.

#16 