### PR TITLE
Add PGP signatures and attestations to build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,16 @@ jobs:
           copy $env:ZIP_FILE_NAME output\artifacts
           $env:CHECKSUM_FILE_NAME_PATH = ("output\artifacts\" + $env:BUILD_FILE_NAME + ".sha256")
           certUtil -hashfile $env:ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $env:CHECKSUM_FILE_NAME_PATH
+      - name: Generate artifacts attestation (Linux & macOS)
+        if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: output/artifacts
+      - name: Generate artifacts attestation (Windows)
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: output\artifacts
       - name: Archive production artifacts (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,12 +102,12 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: output/artifacts
+          subject-path: output/artifacts/*
       - name: Generate artifacts attestation (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: output\artifacts
+          subject-path: output\artifacts\*
       - name: Archive production artifacts (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-          trust_level: 4
+          trust_level: 5
       - name: List GPG keys
         run: gpg -K
       - name: Create archive, checksum and GPG signature (Linux & macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,13 @@ jobs:
           copy $env:ZIP_FILE_NAME output\artifacts
           $env:CHECKSUM_FILE_NAME_PATH = ("output\artifacts\" + $env:BUILD_FILE_NAME + ".sha256")
           certUtil -hashfile $env:ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $env:CHECKSUM_FILE_NAME_PATH
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: List GPG keys
+        run: gpg -K
       - name: Generate artifacts attestation (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on: [workflow_dispatch]
 jobs:
   ci-build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,14 +81,23 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install coreutils
-      - name: Compress the file (Linux & macOS)
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+          trust_level: 4
+      - name: List GPG keys
+        run: gpg -K
+      - name: Create archive, checksum and GPG signature (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         run: |
           tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME}
           mkdir -p output/artifacts
           cp ${BUILD_FILE_NAME}.tar.gz output/artifacts
           sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > output/artifacts/${BUILD_FILE_NAME}.sha256
-      - name: Compress the file (Windows)
+          gpg --sign --armor --output output/artifacts/${BUILD_FILE_NAME}.tar.gz.asc --detach-sig ${BUILD_FILE_NAME}.tar.gz
+      - name: Create archive, checksum and GPG signature (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
         run: |
           $env:ZIP_FILE_NAME = ($env:BUILD_FILE_NAME + ".zip")
@@ -98,13 +107,8 @@ jobs:
           copy $env:ZIP_FILE_NAME output\artifacts
           $env:CHECKSUM_FILE_NAME_PATH = ("output\artifacts\" + $env:BUILD_FILE_NAME + ".sha256")
           certUtil -hashfile $env:ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $env:CHECKSUM_FILE_NAME_PATH
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-      - name: List GPG keys
-        run: gpg -K
+          $env:SIGNATURE_FILE_NAME_PATH = ("output\artifacts\" + $env:ZIP_FILE_NAME + ".asc")
+          gpg --sign --armor --output $env:ZIP_FILE_NAME --detach-sig $env:SIGNATURE_FILE_NAME_PATH
       - name: Generate artifacts attestation (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,14 +91,18 @@ jobs:
         run: gpg -K
       - name: Create archive, checksum and GPG signature (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
+        env:
+          GPG_KEY_ID: $${{ steps.import-gpg-key.outputs.keyid }}
         run: |
           tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME}
           mkdir -p output/artifacts
           cp ${BUILD_FILE_NAME}.tar.gz output/artifacts
           sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > output/artifacts/${BUILD_FILE_NAME}.sha256
-          gpg --sign --armor --output output/artifacts/${BUILD_FILE_NAME}.tar.gz.asc --detach-sig ${BUILD_FILE_NAME}.tar.gz
+          gpg --default-key ${GPG_KEY_ID} --sign --armor --output output/artifacts/${BUILD_FILE_NAME}.tar.gz.asc --detach-sig ${BUILD_FILE_NAME}.tar.gz
       - name: Create archive, checksum and GPG signature (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
+        env:
+          GPG_KEY_ID: $${{ steps.import-gpg-key.outputs.keyid }}
         run: |
           $env:ZIP_FILE_NAME = ($env:BUILD_FILE_NAME + ".zip")
           echo ("ZIP_FILE_NAME=" + $env:ZIP_FILE_NAME) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -108,7 +112,7 @@ jobs:
           $env:CHECKSUM_FILE_NAME_PATH = ("output\artifacts\" + $env:BUILD_FILE_NAME + ".sha256")
           certUtil -hashfile $env:ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $env:CHECKSUM_FILE_NAME_PATH
           $env:SIGNATURE_FILE_NAME_PATH = ("output\artifacts\" + $env:ZIP_FILE_NAME + ".asc")
-          gpg --sign --armor --output $env:ZIP_FILE_NAME --detach-sig $env:SIGNATURE_FILE_NAME_PATH
+          gpg --default-key $env:GPG_KEY_ID --sign --armor --output $env:ZIP_FILE_NAME --detach-sig $env:SIGNATURE_FILE_NAME_PATH
       - name: Generate artifacts attestation (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           $env:CHECKSUM_FILE_NAME_PATH = ("output\artifacts\" + $env:BUILD_FILE_NAME + ".sha256")
           certUtil -hashfile $env:ZIP_FILE_NAME SHA256 | findstr /i /v "SHA256" | findstr /i /v "CertUtil" > $env:CHECKSUM_FILE_NAME_PATH
           $env:SIGNATURE_FILE_NAME_PATH = ("output\artifacts\" + $env:ZIP_FILE_NAME + ".asc")
-          gpg --default-key $env:GPG_KEY_ID --sign --armor --output $env:ZIP_FILE_NAME --detach-sig $env:SIGNATURE_FILE_NAME_PATH
+          gpg --default-key $env:GPG_KEY_ID --sign --armor --output $env:SIGNATURE_FILE_NAME_PATH --detach-sig $env:ZIP_FILE_NAME
       - name: Generate artifacts attestation (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
           brew install coreutils
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
+        id: import-gpg-key
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
@@ -92,7 +93,7 @@ jobs:
       - name: Create archive, checksum and GPG signature (Linux & macOS)
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-') }}
         env:
-          GPG_KEY_ID: $${{ steps.import-gpg-key.outputs.keyid }}
+          GPG_KEY_ID: ${{ steps.import-gpg-key.outputs.fingerprint }}
         run: |
           tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME}
           mkdir -p output/artifacts
@@ -102,7 +103,7 @@ jobs:
       - name: Create archive, checksum and GPG signature (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
         env:
-          GPG_KEY_ID: $${{ steps.import-gpg-key.outputs.keyid }}
+          GPG_KEY_ID: ${{ steps.import-gpg-key.outputs.fingerprint }}
         run: |
           $env:ZIP_FILE_NAME = ($env:BUILD_FILE_NAME + ".zip")
           echo ("ZIP_FILE_NAME=" + $env:ZIP_FILE_NAME) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
+      contents: read
       attestations: write
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR adds 2 new elements to our build process with Github workflows:

1. It create PGP signatures based on the stored PGP private key with Github secrets. It expects 2 secrets: `GPG_PRIVATE_KEY` and `PASSPHRASE` as described with [the import-gpg action](https://github.com/marketplace/actions/import-gpg). I've already added those to the `eth-educators/ethstaker-deposit-cli` repo. You can see [the documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) on this for more details.
2. It creates build attestations to create a strong link between the workflow used to create the release assets and the eventual releases. See [the documentation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for more details.