### PR TITLE
Add parallelism when performing multiple tasks at the same that can benefit from it

### DIFF
--- a/staking_deposit/cli/exit_transaction_keystore.py
+++ b/staking_deposit/cli/exit_transaction_keystore.py
@@ -114,6 +114,8 @@ def exit_transaction_keystore(
     )
 
     folder = os.path.join(output_folder, DEFAULT_EXIT_TRANSACTION_FOLDER_NAME)
+    if not os.path.exists(folder):
+        os.mkdir(folder)
 
     click.echo(load_text(['msg_exit_transaction_creation']))
     saved_folder = export_exit_transaction_json(folder=folder, signed_exit=signed_exit)

--- a/staking_deposit/cli/exit_transaction_mnemonic.py
+++ b/staking_deposit/cli/exit_transaction_mnemonic.py
@@ -1,7 +1,8 @@
 import click
 import os
+import concurrent.futures
 
-from typing import Any, Sequence
+from typing import Any, Sequence, Dict
 from staking_deposit.cli.existing_mnemonic import load_mnemonic_arguments_decorator
 from staking_deposit.credentials import Credential
 from staking_deposit.exceptions import ValidationError
@@ -21,6 +22,22 @@ from staking_deposit.utils.intl import (
     load_text,
 )
 from staking_deposit.utils.validation import validate_int_range, validate_validator_indices, verify_signed_exit_json
+
+
+def _credential_builder(kwargs: Dict[str, Any]) -> Credential:
+    return Credential(**kwargs)
+
+
+def _exit_exporter(kwargs: Dict[str, Any]) -> str:
+    credential: Credential = kwargs.pop('credential')
+    return credential.save_exit_transaction(**kwargs)
+
+
+def _exit_verifier(kwargs: Dict[str, Any]) -> bool:
+    credential: Credential = kwargs.pop('credential')
+    kwargs['pubkey'] = credential.signing_pk.hex()
+    kwargs['chain_settings'] = credential.chain_setting
+    return verify_signed_exit_json(**kwargs)
 
 
 FUNC_NAME = 'exit_transaction_mnemonic'
@@ -94,39 +111,56 @@ def exit_transaction_mnemonic(
     key_indices = range(validator_start_index, validator_start_index + num_keys)
 
     # We are not using CredentialList because from_mnemonic assumes key generation flow
-    credentials = [
-        Credential(
-            mnemonic=mnemonic,
-            mnemonic_password=mnemonic_password,
-            index=key_index,
-            amount=0,  # Unneeded for this purpose
-            chain_setting=chain_settings,
-            hex_eth1_withdrawal_address=None
-        ) for key_index in key_indices
-    ]
+    credentials = []
+    with click.progressbar(length=num_keys, label=load_text(['msg_key_creation']),
+                           show_percent=False, show_pos=True) as bar:
 
-    with click.progressbar(zip(credentials, validator_indices),
-                           label=load_text(['msg_exit_transaction_creation']),
-                           show_percent=False,
-                           length=num_keys,
-                           show_pos=True) as items:
-        transaction_filefolders = [
-            credential.save_exit_transaction(validator_index=validator_index, epoch=epoch, folder=folder)
-            for credential, validator_index in items
-        ]
+        executor_kwargs = [{
+            'mnemonic': mnemonic,
+            'mnemonic_password': mnemonic_password,
+            'index': index,
+            'amount': 0,
+            'chain_setting': chain_settings,
+            'hex_eth1_withdrawal_address': None,
+        } for index in key_indices]
 
-    with click.progressbar(zip(transaction_filefolders, credentials),
-                           label=load_text(['msg_verify_exit_transaction']),
-                           show_percent=False,
-                           length=num_keys,
-                           show_pos=True) as items:
-        if not all(
-            verify_signed_exit_json(file_folder=file,
-                                    pubkey=credential.signing_pk.hex(),
-                                    chain_settings=credential.chain_setting)
-            for file, credential in items
-        ):
-            raise ValidationError(load_text(['err_verify_exit_transactions']))
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            for credential in executor.map(_credential_builder, executor_kwargs):
+                credentials.append(credential)
+                bar.update(1)
+
+    transaction_filefolders = []
+    with click.progressbar(length=num_keys, label=load_text(['msg_exit_transaction_creation']),
+                           show_percent=False, show_pos=True) as bar:
+
+        executor_kwargs = [{
+            'credential': credential,
+            'validator_index': validator_index,
+            'epoch': epoch,
+            'folder': folder,
+        } for credential, validator_index in zip(credentials, validator_indices)]
+
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            for filefolder in executor.map(_exit_exporter, executor_kwargs):
+                transaction_filefolders.append(filefolder)
+                bar.update(1)
+
+    all_valid_exits = True
+    with click.progressbar(length=num_keys, label=load_text(['msg_verify_exit_transaction']),
+                           show_percent=False, show_pos=True) as bar:
+
+        executor_kwargs = [{
+            'file_folder': file,
+            'credential': credential,
+        } for file, credential in zip(transaction_filefolders, credentials)]
+
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            for valid_exit in executor.map(_exit_verifier, executor_kwargs):
+                all_valid_exits &= valid_exit
+                bar.update(1)
+
+    if not all_valid_exits:
+        raise ValidationError(load_text(['err_verify_exit_transactions']))
 
     click.echo(load_text(['msg_creation_success']) + folder)
     click.pause(load_text(['msg_pause']))

--- a/staking_deposit/cli/exit_transaction_mnemonic.py
+++ b/staking_deposit/cli/exit_transaction_mnemonic.py
@@ -129,6 +129,9 @@ def exit_transaction_mnemonic(
                 credentials.append(credential)
                 bar.update(1)
 
+    if not os.path.exists(folder):
+        os.mkdir(folder)
+
     transaction_filefolders = []
     with click.progressbar(length=num_keys, label=load_text(['msg_exit_transaction_creation']),
                            show_percent=False, show_pos=True) as bar:

--- a/staking_deposit/cli/exit_transaction_mnemonic.py
+++ b/staking_deposit/cli/exit_transaction_mnemonic.py
@@ -145,7 +145,6 @@ def exit_transaction_mnemonic(
                 transaction_filefolders.append(filefolder)
                 bar.update(1)
 
-    all_valid_exits = True
     with click.progressbar(length=num_keys, label=load_text(['msg_verify_exit_transaction']),
                            show_percent=False, show_pos=True) as bar:
 
@@ -156,11 +155,9 @@ def exit_transaction_mnemonic(
 
         with concurrent.futures.ProcessPoolExecutor() as executor:
             for valid_exit in executor.map(_exit_verifier, executor_kwargs):
-                all_valid_exits &= valid_exit
                 bar.update(1)
-
-    if not all_valid_exits:
-        raise ValidationError(load_text(['err_verify_exit_transactions']))
+                if not valid_exit:
+                    raise ValidationError(load_text(['err_verify_exit_transactions']))
 
     click.echo(load_text(['msg_creation_success']) + folder)
     click.pause(load_text(['msg_pause']))

--- a/staking_deposit/cli/generate_bls_to_execution_change.py
+++ b/staking_deposit/cli/generate_bls_to_execution_change.py
@@ -203,7 +203,7 @@ def generate_bls_to_execution_change(
             for e in executor.map(_validate_credentials_match, executor_kwargs):
                 bar.update(1)
                 if e is not None:
-                    click.echo('\n[Error] ' + str(e))
+                    click.echo('\n\n[Error] ' + str(e))
                     return
 
     btec_file = credentials.export_bls_to_execution_change_json(bls_to_execution_changes_folder, validator_indices)

--- a/staking_deposit/cli/generate_bls_to_execution_change.py
+++ b/staking_deposit/cli/generate_bls_to_execution_change.py
@@ -1,15 +1,19 @@
 import os
 import click
 import json
+import concurrent.futures
 from typing import (
     Any,
     Sequence,
+    Dict,
+    Optional
 )
 
 from eth_typing import HexAddress
 
 from staking_deposit.credentials import (
     CredentialList,
+    Credential
 )
 from staking_deposit.utils.validation import (
     validate_bls_withdrawal_credentials_list,
@@ -46,6 +50,17 @@ from .existing_mnemonic import (
 
 def get_password(text: str) -> str:
     return click.prompt(text, hide_input=True, show_default=False, type=str)
+
+
+def _validate_credentials_match(kwargs: Dict[str, Any]) -> Optional[ValidationError]:
+    credential: Credential = kwargs.pop('credential')
+    bls_withdrawal_credentials: bytes = kwargs.pop('bls_withdrawal_credentials')
+
+    try:
+        validate_bls_withdrawal_credentials_matching(bls_withdrawal_credentials, credential)
+    except ValidationError as e:
+        return e
+    return None
 
 
 FUNC_NAME = 'generate_bls_to_execution_change'
@@ -177,12 +192,19 @@ def generate_bls_to_execution_change(
     )
 
     # Check if the given old bls_withdrawal_credentials is as same as the mnemonic generated
-    for i, credential in enumerate(credentials.credentials):
-        try:
-            validate_bls_withdrawal_credentials_matching(bls_withdrawal_credentials_list[i], credential)
-        except ValidationError as e:
-            click.echo('\n[Error] ' + str(e))
-            return
+    with click.progressbar(length=len(credentials.credentials), label=load_text(['msg_credentials_verification']),
+                           show_percent=False, show_pos=True) as bar:
+        executor_kwargs = [{
+            'credential': credential,
+            'bls_withdrawal_credentials': bls_withdrawal_credentials_list[i],
+        } for i, credential in enumerate(credentials.credentials)]
+
+        with concurrent.futures.ProcessPoolExecutor() as executor:
+            for e in executor.map(_validate_credentials_match, executor_kwargs):
+                bar.update(1)
+                if e is not None:
+                    click.echo('\n[Error] ' + str(e))
+                    return
 
     btec_file = credentials.export_bls_to_execution_change_json(bls_to_execution_changes_folder, validator_indices)
 

--- a/staking_deposit/credentials.py
+++ b/staking_deposit/credentials.py
@@ -323,7 +323,7 @@ class CredentialList:
         return filefolder
 
     def verify_keystores(self, keystore_filefolders: List[str], password: str) -> bool:
-        valid = True
+        all_valid_keystores = True
         with click.progressbar(length=len(self.credentials),
                                label=load_text(['msg_keystore_verification']),
                                show_percent=False, show_pos=True) as bar:
@@ -335,10 +335,10 @@ class CredentialList:
 
             with concurrent.futures.ProcessPoolExecutor() as executor:
                 for valid_keystore in executor.map(_keystore_verifier, executor_kwargs):
-                    valid &= valid_keystore
+                    all_valid_keystores &= valid_keystore
                     bar.update(1)
 
-        return valid
+        return all_valid_keystores
 
     def export_bls_to_execution_change_json(self, folder: str, validator_indices: Sequence[int]) -> str:
         bls_to_execution_changes = []

--- a/staking_deposit/credentials.py
+++ b/staking_deposit/credentials.py
@@ -271,7 +271,7 @@ class CredentialList:
             )
         key_indices = range(start_index, start_index + num_keys)
 
-        return_list: List[Credential] = []
+        credentials: List[Credential] = []
         with click.progressbar(length=num_keys, label=load_text(['msg_key_creation']),
                                show_percent=False, show_pos=True) as bar:
             executor_kwargs = [{
@@ -285,12 +285,12 @@ class CredentialList:
 
             with concurrent.futures.ProcessPoolExecutor() as executor:
                 for credential in executor.map(_credential_builder, executor_kwargs):
-                    return_list.append(credential)
+                    credentials.append(credential)
                     bar.update(1)
-        return cls(return_list)
+        return cls(credentials)
 
     def export_keystores(self, password: str, folder: str) -> List[str]:
-        return_list: List[str] = []
+        filefolders: List[str] = []
         with click.progressbar(length=len(self.credentials), label=load_text(['msg_keystore_creation']),
                                show_percent=False, show_pos=True) as bar:
             executor_kwargs = [{
@@ -300,10 +300,10 @@ class CredentialList:
             } for credential in self.credentials]
 
             with concurrent.futures.ProcessPoolExecutor() as executor:
-                for keystore in executor.map(_keystore_exporter, executor_kwargs):
-                    return_list.append(keystore)
+                for filefolder in executor.map(_keystore_exporter, executor_kwargs):
+                    filefolders.append(filefolder)
                     bar.update(1)
-        return return_list
+        return filefolders
 
     def export_deposit_data_json(self, folder: str) -> str:
         deposit_data = []

--- a/staking_deposit/deposit.py
+++ b/staking_deposit/deposit.py
@@ -92,7 +92,7 @@ cli.add_command(exit_transaction_mnemonic)
 
 
 def run() -> None:
-    freeze_support() # Needed when running under Windows in a frozen bundle
+    freeze_support()  # Needed when running under Windows in a frozen bundle
     check_python_version()
     cli()
 

--- a/staking_deposit/exit_transaction.py
+++ b/staking_deposit/exit_transaction.py
@@ -48,9 +48,6 @@ def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit) 
     signed_exit_json.update({'message': message})
     signed_exit_json.update({'signature': '0x' + signed_exit.signature.hex()})  # type: ignore[attr-defined]
 
-    if not os.path.exists(folder):
-        os.mkdir(folder)
-
     filefolder = os.path.join(
         folder,
         'signed_exit_transaction-%s-%i.json' % (

--- a/staking_deposit/intl/en/cli/exit_transaction_mnemonic.json
+++ b/staking_deposit/intl/en/cli/exit_transaction_mnemonic.json
@@ -21,6 +21,7 @@
       "arg_exit_transaction_mnemonic_output_folder": {
           "help": "The folder path where the exit transactions will be saved to. Pointing to `./exit_transactions` by default."
       },
+      "msg_key_creation": "Creating your keys:\t",
       "msg_exit_transaction_creation": "Creating your exit transactions:\t",
       "msg_verify_exit_transaction": "Verifying your exit transactions:\t",
       "err_verify_exit_transactions": "\nThere was a problem verifying your exit transactions.\nPlease try again",

--- a/staking_deposit/intl/en/cli/generate_bls_to_execution_change.json
+++ b/staking_deposit/intl/en/cli/generate_bls_to_execution_change.json
@@ -34,6 +34,7 @@
             "help": "The folder path for the keystore(s). Pointing to `./bls_to_execution_changes` by default."
         },
         "msg_key_creation": "Creating your SignedBLSToExecutionChange.",
+        "msg_credentials_verification": "Verifying your withdrawal credentials.",
         "msg_creation_success": "\nSuccess!\nYour SignedBLSToExecutionChange JSON file can be found at: ",
         "msg_pause": "\n\nPress any key.",
         "err_verify_btec": "Failed to verify the bls_to_execution_change JSON files."

--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -53,7 +53,7 @@ def verify_deposit_data_json(filefolder: str, credentials: Sequence[Credential])
     """
     Validate every deposit found in the deposit-data JSON file folder.
     """
-    valid = True
+    all_valid_deposits = True
     deposit_json = []
     with open(filefolder, 'r', encoding='utf-8') as f:
         deposit_json = json.load(f)
@@ -67,10 +67,10 @@ def verify_deposit_data_json(filefolder: str, credentials: Sequence[Credential])
 
         with concurrent.futures.ProcessPoolExecutor() as executor:
             for valid_deposit in executor.map(_deposit_validator, executor_kwargs):
-                valid &= valid_deposit
+                all_valid_deposits &= valid_deposit
                 bar.update(1)
 
-    return valid
+    return all_valid_deposits
 
 
 def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential) -> bool:
@@ -185,7 +185,7 @@ def verify_bls_to_execution_change_json(filefolder: str,
     with open(filefolder, 'r', encoding='utf-8') as f:
         btec_json = json.load(f)
 
-    valid = True
+    all_valid_bls_changes = True
     with click.progressbar(length=len(btec_json), label=load_text(['msg_bls_to_execution_change_verification']),
                            show_percent=False, show_pos=True) as bar:
 
@@ -199,10 +199,10 @@ def verify_bls_to_execution_change_json(filefolder: str,
 
         with concurrent.futures.ProcessPoolExecutor() as executor:
             for valid_bls_change in executor.map(_bls_to_execution_change_validator, executor_kwargs):
-                valid &= valid_bls_change
+                all_valid_bls_changes &= valid_bls_change
                 bar.update(1)
 
-    return valid
+    return all_valid_bls_changes
 
 
 def validate_bls_to_execution_change(btec_dict: Dict[str, Any],

--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -43,11 +43,6 @@ from staking_deposit.settings import BaseChainSetting
 # Deposit
 #
 
-def _deposit_validator(kwargs: Dict[str, Any]) -> bool:
-    deposit: Dict[str, Any] = kwargs.pop('deposit')
-    credential: Credential = kwargs.pop('credential')
-    return validate_deposit(deposit, credential)
-
 
 def verify_deposit_data_json(filefolder: str, credentials: Sequence[Credential]) -> bool:
     """
@@ -60,13 +55,9 @@ def verify_deposit_data_json(filefolder: str, credentials: Sequence[Credential])
 
     with click.progressbar(length=len(deposit_json), label=load_text(['msg_deposit_verification']),
                            show_percent=False, show_pos=True) as bar:
-        executor_kwargs = [{
-            'credential': credential,
-            'deposit': deposit,
-        } for deposit, credential in zip(deposit_json, credentials)]
 
         with concurrent.futures.ProcessPoolExecutor() as executor:
-            for valid_deposit in executor.map(_deposit_validator, executor_kwargs):
+            for valid_deposit in executor.map(validate_deposit, deposit_json, credentials):
                 all_valid_deposits &= valid_deposit
                 bar.update(1)
 

--- a/test_binary_btec_script.py
+++ b/test_binary_btec_script.py
@@ -61,6 +61,8 @@ async def main(argv):
 
     assert len(seed_phrase) > 0
 
+    await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))

--- a/test_binary_deposit_script.py
+++ b/test_binary_deposit_script.py
@@ -57,6 +57,8 @@ async def main(argv):
 
     assert len(seed_phrase) > 0
 
+    await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))

--- a/test_btec_script.py
+++ b/test_btec_script.py
@@ -66,6 +66,8 @@ async def main():
 
     assert len(seed_phrase) > 0
 
+    await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))

--- a/test_deposit_script.py
+++ b/test_deposit_script.py
@@ -62,6 +62,8 @@ async def main():
 
     assert len(seed_phrase) > 0
 
+    await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -281,6 +281,7 @@ async def test_script() -> None:
         ' '.join(cmd_args),
     )
     await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))
@@ -329,6 +330,7 @@ async def test_script_abbreviated_mnemonic() -> None:
         ' '.join(cmd_args),
     )
     await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -409,6 +409,8 @@ async def test_script_bls_withdrawal() -> None:
 
     assert len(seed_phrase) > 0
 
+    await proc.wait()
+
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     _, _, key_files = next(os.walk(validator_keys_folder_path))
@@ -494,6 +496,8 @@ async def test_script_abbreviated_mnemonic() -> None:
                 proc.stdin.write(b'\n')
 
     assert len(seed_phrase) > 0
+
+    await proc.wait()
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)


### PR DESCRIPTION
This PR adds parallelism using [the ProcessPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor) when and where we can benefit from executing multiple tasks on potentially multiple cores. This speeds up keys generation, keystores generation, voluntary exits generation and a bunch of verification especially when multiples are requested. It will default to using number of processors on the machine for the number of workers.

Fixes #40 

Introduces #47 