### PR TITLE
Adding try/except when running cli to remove stack traces

### DIFF
--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -99,7 +99,8 @@ def run() -> None:
     try:
         cli()
     except (ValueError, ValidationError) as e:
-        click.echo(f"\nError: {e}\n")
+        click.echo(f"\nError: {e}\n", err=True)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -8,6 +8,7 @@ from ethstaker_deposit.cli.exit_transaction_keystore import exit_transaction_key
 from ethstaker_deposit.cli.exit_transaction_mnemonic import exit_transaction_mnemonic
 from ethstaker_deposit.cli.generate_bls_to_execution_change import generate_bls_to_execution_change
 from ethstaker_deposit.cli.new_mnemonic import new_mnemonic
+from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.utils.click import (
     captive_prompt_callback,
     choice_prompt_func,
@@ -94,7 +95,11 @@ cli.add_command(exit_transaction_mnemonic)
 def run() -> None:
     freeze_support()  # Needed when running under Windows in a frozen bundle
     check_python_version()
-    cli()
+
+    try:
+        cli()
+    except (ValueError, ValidationError) as e:
+        click.echo(f"\nError: {e}\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of showing a massive stack trace for thrown errors, we will now wrap the `cli()` call and catch and `ValidatorError` or `ValueError` and then display what the error is.

To reproduce a stack traced ValidationError:
```
python3 -m ethstaker_deposit --non_interactive --language english existing-mnemonic --mnemonic="1234 4321 1234"
```

To reproduce a stack traced ValueError:
```
python3 -m ethstaker_deposit --language english --non_interactive generate-bls-to-execution-change --mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" --chain="mainnet" --validator_start_index=0 --validator_indices="1 2" --bls_withdrawal_credentials_list=00245ac28e1ed7eb69d62af7bfbde0e154e749eaf80e208e947dde4c1ed236ad --execution_address="0x00000000219ab540356cBB839Cbe05303d7705Fa"
```

Fixes #18 