### PR TITLE
Update zipp package for security issue

### DIFF
--- a/build_configs/common/requirements.txt
+++ b/build_configs/common/requirements.txt
@@ -83,9 +83,9 @@ pyinstaller-hooks-contrib==2024.1 \
 importlib-metadata==7.0.1 \
     --hash=sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e \
     --hash=sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc
-zipp==3.17.0 \
-    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
-    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
+zipp==3.19.2 \
+    --hash=sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19 \
+    --hash=sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c
 typing-extensions==4.9.0 \
     --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
     --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd


### PR DESCRIPTION
Fixes https://github.com/eth-educators/ethstaker-deposit-cli/security/dependabot/2

This dependency is only used during build. I started a new build process on https://github.com/remyroy/ethstaker-deposit-cli/actions/runs/9877400806 and everything was fine. After merging, we should start another build process on this repository to confirm.