### PR TITLE
Add docker workflow and improve dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,6 @@
 #
-name: Create and publish a Docker image
+name: ci-docker
+run-name: ${{ github.actor }} is running ci-docker
 
 # Configures this workflow to run every time a change is pushed to a tag that starts with `v`.
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to a tag that starts with `v`.
+on:
+  push:
+    tags:
+      - v*
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.19
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
@@ -6,12 +6,6 @@ COPY requirements.txt ./
 
 COPY ethstaker_deposit ./ethstaker_deposit
 
-RUN apk add --update gcc libc-dev linux-headers
-
 RUN pip3 install -r requirements.txt
 
-ARG cli_command
-
 ENTRYPOINT [ "python3", "-m", "ethstaker_deposit" ]
-
-CMD [ $cli_command ]


### PR DESCRIPTION
Fixes #61

This PR slightly improves the current docker image and it creates a github workflow to build and publish the docker image on the github registry. The workflow is triggerd on pushing a tag that starts with `v`. It should be the convention when performing a release to add a related tag that starts with `v` and the version number.

An example of the result of this can be found on https://github.com/remyroy/ethstaker-deposit-cli/actions/runs/10013809719 . The related package can be found on https://github.com/remyroy/ethstaker-deposit-cli/pkgs/container/ethstaker-deposit-cli. Some of the related documentation can be found on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images .

You can use this test docker image with something like:
```
docker pull ghcr.io/remyroy/ethstaker-deposit-cli:latest
docker run -it ghcr.io/remyroy/ethstaker-deposit-cli
```
From there, you can add any arguments like:
```
docker run -it ghcr.io/remyroy/ethstaker-deposit-cli new-mnemonic --chain holesky
```

We'll need to change the documentation in regards with the registry used. It's going to be `ghcr.io` instead of the official docker hub after our first test release.