### PR TITLE
Share timestamp across generated files for an action

### DIFF
--- a/ethstaker_deposit/cli/exit_transaction_keystore.py
+++ b/ethstaker_deposit/cli/exit_transaction_keystore.py
@@ -1,5 +1,6 @@
 import click
 import os
+import time
 
 from typing import Any
 from ethstaker_deposit.exit_transaction import exit_transaction_generation, export_exit_transaction_json
@@ -118,7 +119,7 @@ def exit_transaction_keystore(
         os.mkdir(folder)
 
     click.echo(load_text(['msg_exit_transaction_creation']))
-    saved_folder = export_exit_transaction_json(folder=folder, signed_exit=signed_exit)
+    saved_folder = export_exit_transaction_json(folder=folder, signed_exit=signed_exit, timestamp=time.time())
 
     click.echo(load_text(['msg_verify_exit_transaction']))
     if (not verify_signed_exit_json(saved_folder, keystore.pubkey, chain_settings)):

--- a/ethstaker_deposit/cli/exit_transaction_mnemonic.py
+++ b/ethstaker_deposit/cli/exit_transaction_mnemonic.py
@@ -1,6 +1,7 @@
 import click
-import os
 import concurrent.futures
+import os
+import time
 
 from typing import Any, Sequence, Dict
 from ethstaker_deposit.cli.existing_mnemonic import load_mnemonic_arguments_decorator
@@ -141,6 +142,7 @@ def exit_transaction_mnemonic(
             'validator_index': validator_index,
             'epoch': epoch,
             'folder': folder,
+            'timestamp': time.time(),
         } for credential, validator_index in zip(credentials, validator_indices)]
 
         with concurrent.futures.ProcessPoolExecutor() as executor:

--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -1,5 +1,6 @@
-import os
 import click
+import os
+import time
 from typing import (
     Any,
     Callable,
@@ -142,8 +143,11 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
         hex_withdrawal_address=withdrawal_address,
         use_pbkdf2=pbkdf2
     )
-    keystore_filefolders = credentials.export_keystores(password=keystore_password, folder=folder)
-    deposits_file = credentials.export_deposit_data_json(folder=folder)
+
+    timestamp = time.time()
+
+    keystore_filefolders = credentials.export_keystores(password=keystore_password, folder=folder, timestamp=timestamp)
+    deposits_file = credentials.export_deposit_data_json(folder=folder, timestamp=timestamp)
     if not credentials.verify_keystores(keystore_filefolders=keystore_filefolders, password=keystore_password):
         raise ValidationError(load_text(['err_verify_keystores']))
     if not verify_deposit_data_json(deposits_file, credentials.credentials):

--- a/ethstaker_deposit/exit_transaction.py
+++ b/ethstaker_deposit/exit_transaction.py
@@ -1,6 +1,5 @@
 import json
 import os
-import time
 from typing import Any, Dict
 from py_ecc.bls import G2ProofOfPossession as bls
 
@@ -39,7 +38,7 @@ def exit_transaction_generation(
     return signed_exit
 
 
-def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit) -> str:
+def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit, timestamp: float) -> str:
     signed_exit_json: Dict[str, Any] = {}
     message = {
         'epoch': str(signed_exit.message.epoch),  # type: ignore[attr-defined]
@@ -51,7 +50,8 @@ def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit) 
     filefolder = os.path.join(
         folder,
         'signed_exit_transaction-%s-%i.json' % (
-            signed_exit.message.validator_index, time.time()  # type: ignore[attr-defined]
+            signed_exit.message.validator_index,  # type: ignore[attr-defined]
+            timestamp,
         )
     )
 

--- a/tests/test_cli/test_exit_transaction_keystore.py
+++ b/tests/test_cli/test_exit_transaction_keystore.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from click.testing import CliRunner
 
@@ -41,7 +42,7 @@ def test_exit_transaction_keystore() -> None:
     )
 
     # Save keystore file
-    keystore_filepath = credential.save_signing_keystore(keystore_password, exit_transaction_folder_path)
+    keystore_filepath = credential.save_signing_keystore(keystore_password, exit_transaction_folder_path, time.time())
 
     runner = CliRunner()
     arguments = [
@@ -126,10 +127,12 @@ def test_exit_transaction_with_pbkdf2() -> None:
     pbkdf2_keystore_filepath = pbkdf2_credential.save_signing_keystore(
         keystore_password,
         pbkdf2_exit_transaction_folder_path,
+        time.time(),
     )
     scrypt_keystore_filepath = scrypt_credential.save_signing_keystore(
         keystore_password,
         scrypt_exit_transaction_folder_path,
+        time.time(),
     )
 
     runner = CliRunner()
@@ -260,7 +263,7 @@ def test_invalid_keystore_password() -> None:
     )
 
     # Save keystore file
-    keystore_filepath = credential.save_signing_keystore(keystore_password, exit_transaction_folder_path)
+    keystore_filepath = credential.save_signing_keystore(keystore_password, exit_transaction_folder_path, time.time())
     runner = CliRunner()
     inputs = []
     data = '\n'.join(inputs)


### PR DESCRIPTION
Instead of generating a timestamp at the time of file creation, the value will be provided when files are created in bulk such as generating keys or exit transactions for mnemonics.

Fixes #35 