### PR TITLE
Exclude Python 3.9 and macOS from CI matrix

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -12,6 +12,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: "3.9"
+          - os: macos-12
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
This is a workaround for #62 until I can find a better solution.