### PR TITLE
Use an older version of Ubuntu for building to support users on older glibc versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-12, macos-latest, windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should help with users who are on older linux OSes and those that are using an older version of glibc.