### PR TITLE
Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-13, macos-latest, windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           mkdir ${BUILD_FILE_NAME}
           pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec
       - name: Build with build.spec (macOS amd64)
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.os == 'macos-13' }}
         run: |
           export BUILD_FILE_NAME=ethstaker_deposit-cli-${SHORT_SHA}-darwin-amd64
           echo "BUILD_FILE_NAME=${BUILD_FILE_NAME}" >> "$GITHUB_ENV"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
         exclude:
           - os: macos-latest
             python-version: "3.9"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,12 +7,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest
             python-version: "3.9"
-          - os: macos-12
+          - os: macos-13
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Merge after the Python 3.13 runner is available. See also #74 

Changed `macos-12` to `macos-13` because of:

"While this release of 3.12 still supports them, it is likely that we will be forced to drop support for macOS 10.12 and older in a future 3.12 release. (Python 3.13 has already dropped support for them.)"

macOS is usually supported for 3 years, which means 12 would become unsupported when 15 releases, likely late October. https://endoflife.date/macos