### PR TITLE
Check terminal encoding

### DIFF
--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -31,7 +31,7 @@ def check_python_version() -> None:
     '''
     if sys.version_info < (3, 9):
         click.pause(load_text(['err_python_version']))
-        sys.exit()
+        sys.exit(78)
 
 
 def check_connectivity() -> None:

--- a/ethstaker_deposit/intl/en/utils/validation.json
+++ b/ethstaker_deposit/intl/en/utils/validation.json
@@ -3,7 +3,9 @@
         "msg_deposit_verification": "Verifying your deposit_data-*.json file(s):\t"
     },
     "validate_password_strength": {
-        "msg_password_length": "The password length should be at least 8. Please retype"
+        "msg_password_length": "The password length should be at least 8. Please retype.",
+        "msg_password_utf8_win32": "Your terminal is not UTF-8 encoded. To ensure the keystore file can be imported on Linux, the password should contain only English-language characters. Please retype.",
+        "msg_password_utf8": "Your terminal is not UTF-8 encoded. To ensure the keystore file can be imported on Linux, the password should contain only English-language characters. Please retype.\nAlternatively, you can quit this program and relaunch it from a UTF-8 encoded terminal."
     },
     "validate_int_range": {
         "err_not_positive_integer": "That is not a positive integer. Please retype."
@@ -14,7 +16,7 @@
     "validate_withdrawal_address": {
         "err_invalid_ECDSA_hex_addr": "The given execution address is not in hexadecimal encoded form.",
         "err_invalid_ECDSA_hex_addr_checksum": "The given execution address is not in checksum form.",
-        "err_missing_address": "An address must must be providing",
+        "err_missing_address": "An address must be provided",
         "msg_ECDSA_hex_addr_withdrawal": "**[Warning] you are setting an execution address as your withdrawal address. Please ensure that you have control over this address.**"
     },
     "validate_partial_deposit_amount": {

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -2,6 +2,7 @@ from decimal import Decimal, InvalidOperation
 import click
 import json
 import re
+import sys
 import concurrent.futures
 from typing import Any, Dict, Sequence
 
@@ -138,6 +139,14 @@ def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential =
 def validate_password_strength(password: str) -> str:
     if len(password) < 8:
         raise ValidationError(load_text(['msg_password_length']))
+
+    encoding = sys.stdin.encoding.lower()
+    if encoding != 'utf-8' and not password.isascii():
+        if sys.platform == 'win32':
+            raise ValidationError(load_text(['msg_password_utf8_win32']))
+        else:
+            raise ValidationError(load_text(['msg_password_utf8']))
+
     return password
 
 

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -12,7 +12,7 @@ from tests.test_cli.helpers import clean_key_folder
 def test_should_notify_user_and_exit_if_invalid_python_version(monkeypatch) -> None:
     exit_called = False
 
-    def _mock_sys_exit():
+    def _mock_sys_exit(arg):
         nonlocal exit_called
         exit_called = True
 


### PR DESCRIPTION
Resolves #34 

## Changes

Checks for utf-8 terminal encoding on password strength check. If not `utf-8` and the password isn't ASCII, ask the user to retype.

If the platform is not Windows, suggest to switch to a `utf-8` terminal instead.

utf-8 terminal is not a standard on Windows, it uses "a zoo of code pages"

utf-8 console on Windows in Python is alas also not a thing. [PEP528](https://peps.python.org/pep-0528/) has been around since 2016, don't hold your breath.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Notes on testing

The reason this failed in the Windows runner for staking-deposit-cli was that they checked only for `utf-8`, and Windows does not do `utf-8`.
