### PR TITLE
Add coverage reports to github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+relative_files = True
+omit =
+    tests/**

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,36 @@
+# Safely comment on the PR - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+name: Comment on pull request
+run-name: commenting on PR by ${{ github.actor }}
+on:
+  workflow_run:
+    workflows: [ "ci-runner" ]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./issue_number'));
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: fs.readFileSync('./coverage-text-report').toString()
+            });

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -26,9 +26,52 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements_test.txt
+          pip install coverage
       - name: Run tests
-        run: pytest tests
+        run: |
+          coverage run --data-file=.coverage.${{ matrix.os }}.${{ matrix.python-version }} -m pytest tests
       - name: Run type checker
         run: python -m mypy --config-file mypy.ini -p ethstaker_deposit
       - name: Run linter
         run: flake8 --config=flake8.ini ./ethstaker_deposit ./tests
+      - name: Upload coverage data 
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
+          path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}
+          retention-days: 1
+  coverage-combine:
+    needs: ci-runner
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+      - name: Merge coverage data
+        id: merge
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage
+          coverage combine coverage*
+          coverage html
+      - name: Upload final coverage html report
+        uses: actions/upload-artifact@v4
+        id: upload-html
+        with:
+          name: coverage-html-report
+          path: htmlcov
+      - name: Generate text report
+        run: |
+          mkdir results
+          echo "Test Coverage: [Download HTML Report](${{ steps.upload-html.outputs.artifact-url }})" >> results/coverage-text-report
+          echo >> results/coverage-text-report
+          echo \`\`\` >> results/coverage-text-report
+          coverage report >> results/coverage-text-report
+          echo \`\`\` >> results/coverage-text-report
+          echo ${{ github.event.number }} > results/issue_number
+      - name: Upload final coverage text report
+        uses: actions/upload-artifact@v4
+        with:
+          name: results 
+          path: results/ 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv/
 *.egg
 __pycache__
 .DS_Store
+.coverage


### PR DESCRIPTION
Uses [coverage.py](https://coverage.readthedocs.io/en/7.6.1/) to produce coverage reports in CI.
Special care is given to avoid the security snafus in [this article](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)

`relative_files = True` is required for cross-platform compatibility when merging coverage reports generated by the run matrix.

An html report is generated and uploaded to github (retention 60 days), as well as a text summary.
The text summary and a link to the html report are added to the pull request as a comment.

Screenshots for reference:

![image](https://github.com/user-attachments/assets/aee47b83-360d-436a-a4fa-1fd682837284)

![image](https://github.com/user-attachments/assets/d249cd77-1ae5-4db8-b35b-fa4eb0f3dcf1)

![image](https://github.com/user-attachments/assets/36bd0b75-a67c-4bf8-9d18-d18c74851fbe)

![image](https://github.com/user-attachments/assets/fe7484d5-0512-4893-a0f7-a398e6220666)

NB: "comment" workflow file is added in a separate commit since it needs to reside on the target branch (see above link for security explanation)