### PR TITLE
Granular test skip on macOS Python 3.9

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -8,12 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: macos-12
-            python-version: "3.9"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -438,6 +439,7 @@ def test_pbkdf2_new_mnemonic(monkeypatch) -> None:
     clean_key_folder(scrypt_folder_path)
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 9) and sys.platform == "darwin", reason="breaks on macOS Python 3.9")
 @pytest.mark.asyncio
 async def test_script_bls_withdrawal() -> None:
     # Prepare folder
@@ -525,6 +527,7 @@ async def test_script_bls_withdrawal() -> None:
     clean_key_folder(my_folder_path)
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 9) and sys.platform == "darwin", reason="breaks on macOS Python 3.9")
 @pytest.mark.asyncio
 async def test_script_abbreviated_mnemonic() -> None:
     # Prepare folder


### PR DESCRIPTION
## Changes

Instead of skipping all tests on macOS Python 3.9, skip just the ones that use asyncio PIPE

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_
