### PR TITLE
Document canonical deposit contract and launchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
   - [Run tests](#run-tests)
   - [Run the app](#run-the-app)
   - [Building Binaries](#building-binaries)
-      - [Mac M1 Binaries](#mac-m1-binaries)
+- [Canonical Deposit Contract and Launchpad](#canonical-deposit-contract-and-launchpad)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -647,10 +647,26 @@ python3 -m ethstaker_deposit [OPTIONS] COMMAND [ARGS]
 
 ### Building Binaries
 **Developers Only**
-##### Mac M1 Binaries
 
-👋This is not the section you are looking for.👋
-If you are trying to **build the binary** on macos with an M1 Mac and you are using pyenv to manage your python version. You'll probably need to reinstall a given python version using:
+ethstaker-deposit uses `pyinstaller` to create binaries. The requirements are in `build_configs`. Look at `.circleci/config.yml` to see it in action.
+
+For example Linux, in your Python virtual environment:
+```sh
+export BUILD_FILE_NAME=ethstaker_deposit-cli-dev-linux
+pip install -r ./build_configs/linux/requirements.txt
+pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec
 ```
-env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.10.3
-```
+
+## Canonical Deposit Contract and Launchpad
+
+Ethstaker confirms the canonical Ethereum staking deposit contract addresses and launchpad URLs.
+Please be sure that your ETH is deposited only to this deposit contract address, depending on chain.
+
+Depositing to the wrong address **will** lose you your ETH.
+
+- Ethereum mainnet
+  - Deposit address: [0x00000000219ab540356cBB839Cbe05303d7705Fa](https://etherscan.io/address/0x00000000219ab540356cBB839Cbe05303d7705Fa)
+  - [Launchpad](https://launchpad.ethereum.org/)
+- Ethereum Holešky (Holešovice) testnet
+  - Deposit address: [0x4242424242424242424242424242424242424242](https://holesky.etherscan.io/address/0x4242424242424242424242424242424242424242)
+  - [Launchpad](https://holesky.launchpad.ethereum.org/)

--- a/docs/src/landing.md
+++ b/docs/src/landing.md
@@ -52,6 +52,20 @@ If there is a specific command you would like to understand more, please choose 
 
 - **[exit-transaction-mnemonic](exit_transaction_mnemonic.md)**: Generate an exit message using the mnemonic of your validators.
 
+## Canonical Deposit Contract and Launchpad
+
+Ethstaker confirms the canonical Ethereum staking deposit contract addresses and launchpad URLs.
+Please be sure that your ETH is deposited only to this deposit contract address, depending on chain.
+
+Depositing to the wrong address **will** lose you your ETH.
+
+- Ethereum mainnet
+  - Deposit address: [0x00000000219ab540356cBB839Cbe05303d7705Fa](https://etherscan.io/address/0x00000000219ab540356cBB839Cbe05303d7705Fa)
+  - [Launchpad](https://launchpad.ethereum.org/)
+- Ethereum Holešky (Holešovice) testnet
+  - Deposit address: [0x4242424242424242424242424242424242424242](https://holesky.etherscan.io/address/0x4242424242424242424242424242424242424242)
+  - [Launchpad](https://holesky.launchpad.ethereum.org/)
+
 ## Contributing
 
 This project is open-source and welcomes contributions from the community. If you would like to contribute to the `ethstaker-deposit-cli`, please read the [Local Development Instructions](local_development.md), fork the project, and create a pull request with a description of the changes you have made and why.


### PR DESCRIPTION
Closes #54 

## Changes

Document the canonical deposit contract address and launchpad URL for mainnet and Holesky

Also document binary creation for developers

`doctoc` has been run to update the ToC

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
