### PR TITLE
Establish Valefar and Remy as global code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @valefar-on-discord @remyroy


### PR DESCRIPTION
## Changes

Create a `CODEOWNERS` file

This allow us in a future step to require review from a code owner, once we get to the more serious issues.

This is arguably a security feature as right now anyone in the org can do an approving review.

We may also want to look at who is admin and can change the protection settings.