### PR TITLE
Don't prompt for `--language` when `--non_interactive`

### DIFF
--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -15,6 +15,7 @@ from ethstaker_deposit.utils.click import (
     captive_prompt_callback,
     choice_prompt_func,
     jit_option,
+    deactivate_prompts_callback
 )
 from ethstaker_deposit.utils import config
 from ethstaker_deposit.utils.constants import INTL_LANG_OPTIONS
@@ -81,6 +82,7 @@ class SortedGroup(click.Group):
 )
 @click.option(
     '--non_interactive',
+    callback=deactivate_prompts_callback(["language"]),
     default=False,
     is_flag=True,
     help=(


### PR DESCRIPTION
Closes #19 

## Changes

`--non_interactive` disables the `--language` prompt in the first top-level Click context

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
