### PR TITLE
Arm64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-13, macos-latest, windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,8 +7,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm64, macos-13, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
+        exclude:
+          - os: ubuntu-24.04-arm64
+            python-version: "3.13.0-rc.1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,8 +1,15 @@
 name: ci-runner
 run-name: ${{ github.actor }} is running ci-runner
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+    branches: [main]
 jobs:
   ci-runner:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'run-tests') ||
+      github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Changes

Add custom ubuntu arm64 runners

Added a `run-tests` label. This way we can avoid running tests for documentation PRs or when a PR has been opened for code review and discussion and isn't ready for testing yet

Windows 11 ARM64 runners do not support Python at all presently. We can try again when they are out of beta at the end of the year.