### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '7.1.1'
+    hooks:
+    - id: flake8
+      files: ^(ethstaker_deposit|tests)/
+      args: [--config, flake8.ini]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.11.2'
+    hooks:
+    - id: mypy
+      additional_dependencies: 
+        - click==8.1.7
+        - eth-typing==5.0.0
+        - eth-utils==5.0.0
+        - pycryptodome==3.20.0
+        - py-ecc==7.0.1
+        - ssz==0.5.0
+      files: ^ethstaker_deposit/
+      args: [--config-file, mypy.ini]

--- a/README.md
+++ b/README.md
@@ -670,6 +670,19 @@ python3 -m pytest tests
 python3 -m ethstaker_deposit [OPTIONS] COMMAND [ARGS]
 ```
 
+### Use pre-commit
+
+Install `pre-commit` if not already installed, e.g. for Debian/Ubuntu:
+
+```sh
+sudo apt update && sudo apt install pre-commit
+```
+
+Enable it for your `git commit` workflow:
+```sh
+pre-commit install
+```
+
 ### Building Binaries
 **Developers Only**
 

--- a/docs/src/local_development.md
+++ b/docs/src/local_development.md
@@ -27,10 +27,17 @@ Ensure you have the following software installed on your system:
 
 3. **Setup virtualenv (optional)**
 
+    Install `venv` if not already installed, e.g. for Debian/Ubuntu:
+
     ```sh
-    pip3 install virtualenv
-    virtualenv venv
-    .\venv\Scripts\activate
+    sudo apt update && sudo apt install python3-venv
+    ```
+
+    Create a new [virtual environment](https://docs.python.org/3/library/venv.html):
+
+    ```sh
+    python3 -m venv .venv
+    source .venv/bin/activate
     ```
 
 4. **Install Dependencies**
@@ -45,6 +52,19 @@ Ensure you have the following software installed on your system:
 
     ```sh
     python3 -m ethstaker_deposit [OPTIONS] COMMAND [ARGS]
+    ```
+
+6. **Use pre-commit for PRs**
+
+    Install `pre-commit` if not already installed, e.g. for Debian/Ubuntu:
+
+    ```sh
+    sudo apt update && sudo apt install pre-commit
+    ```
+
+    Enable it for your `git commit` workflow:
+    ```sh
+    pre-commit install
     ```
 
 **To execute tests, you will need to install the test dependencies**:


### PR DESCRIPTION
## Changes

Add a pre-commit config and documentation. This allows devs to run `flake8` and `mypy` locally on commit, reducing iteration on a PR because of linter/typing failures

I have run `pre-commit run --all-files` and it passes

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No
