### PR TITLE
List becomes list

### DIFF
--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -4,7 +4,7 @@ from enum import Enum
 import time
 import json
 import concurrent.futures
-from typing import Dict, List, Optional, Any, Sequence
+from typing import Dict, Optional, Any, Sequence
 
 from eth_typing import Address, HexAddress
 from eth_utils import to_canonical_address
@@ -259,7 +259,7 @@ class CredentialList:
     """
     A collection of multiple Credentials, one for each validator.
     """
-    def __init__(self, credentials: List[Credential]):
+    def __init__(self, credentials: list[Credential]):
         self.credentials = credentials
 
     @classmethod
@@ -268,7 +268,7 @@ class CredentialList:
                       mnemonic: str,
                       mnemonic_password: str,
                       num_keys: int,
-                      amounts: List[int],
+                      amounts: list[int],
                       chain_setting: BaseChainSetting,
                       start_index: int,
                       hex_withdrawal_address: Optional[HexAddress],
@@ -279,7 +279,7 @@ class CredentialList:
             )
         key_indices = range(start_index, start_index + num_keys)
 
-        credentials: List[Credential] = []
+        credentials: list[Credential] = []
         with click.progressbar(length=num_keys, label=load_text(['msg_key_creation']),  # type: ignore[var-annotated]
                                show_percent=False, show_pos=True) as bar:
             executor_kwargs = [{
@@ -298,8 +298,8 @@ class CredentialList:
                     bar.update(1)
         return cls(credentials)
 
-    def export_keystores(self, password: str, folder: str, timestamp: float) -> List[str]:
-        filefolders: List[str] = []
+    def export_keystores(self, password: str, folder: str, timestamp: float) -> list[str]:
+        filefolders: list[str] = []
         with click.progressbar(length=len(self.credentials),  # type: ignore[var-annotated]
                                label=load_text(['msg_keystore_creation']),
                                show_percent=False, show_pos=True) as bar:
@@ -329,7 +329,7 @@ class CredentialList:
 
         return export_deposit_data_json_util(folder, timestamp, deposit_data)
 
-    def verify_keystores(self, keystore_filefolders: List[str], password: str) -> bool:
+    def verify_keystores(self, keystore_filefolders: list[str], password: str) -> bool:
         all_valid_keystores = True
         with click.progressbar(length=len(self.credentials),  # type: ignore[var-annotated]
                                label=load_text(['msg_keystore_verification']),

--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -2,7 +2,6 @@ import click
 import socket
 import sys
 from multiprocessing import freeze_support
-from typing import List
 
 from ethstaker_deposit.cli.existing_mnemonic import existing_mnemonic
 from ethstaker_deposit.cli.exit_transaction_keystore import exit_transaction_keystore
@@ -61,7 +60,7 @@ commands = [
 
 class SortedGroup(click.Group):
 
-    def list_commands(self, ctx: click.Context) -> List[str]:
+    def list_commands(self, ctx: click.Context) -> list[str]:
         return [x.name for x in commands]
 
 

--- a/ethstaker_deposit/key_handling/key_derivation/mnemonic.py
+++ b/ethstaker_deposit/key_handling/key_derivation/mnemonic.py
@@ -2,7 +2,6 @@ import os
 from unicodedata import normalize
 from secrets import randbits
 from typing import (
-    List,
     Optional,
     Sequence,
 )
@@ -93,7 +92,7 @@ def _get_checksum(entropy: bytes) -> int:
     return int.from_bytes(SHA256(entropy), 'big') >> (256 - checksum_length)
 
 
-def abbreviate_words(words: Sequence[str]) -> List[str]:
+def abbreviate_words(words: Sequence[str]) -> list[str]:
     """
     Given a series of word strings, return the 4-letter version of each word (which is unique according to BIP39)
     """

--- a/ethstaker_deposit/key_handling/key_derivation/path.py
+++ b/ethstaker_deposit/key_handling/key_derivation/path.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from .mnemonic import get_seed
 from .tree import (
     derive_master_SK,
@@ -7,7 +5,7 @@ from .tree import (
 )
 
 
-def path_to_nodes(path: str) -> List[int]:
+def path_to_nodes(path: str) -> list[int]:
     """
     Maps from a path string to a list of indices where each index represents the corresponding level in the path.
     """

--- a/ethstaker_deposit/key_handling/key_derivation/tree.py
+++ b/ethstaker_deposit/key_handling/key_derivation/tree.py
@@ -3,7 +3,6 @@ from ethstaker_deposit.utils.crypto import (
     SHA256,
 )
 from py_ecc.optimized_bls12_381 import curve_order as bls_curve_order
-from typing import List
 
 
 def _flip_bits_256(input: int) -> int:
@@ -13,7 +12,7 @@ def _flip_bits_256(input: int) -> int:
     return input ^ (2**256 - 1)
 
 
-def _IKM_to_lamport_SK(*, IKM: bytes, salt: bytes) -> List[bytes]:
+def _IKM_to_lamport_SK(*, IKM: bytes, salt: bytes) -> list[bytes]:
     """
     Derives the lamport SK for a given `IKM` and `salt`.
 

--- a/ethstaker_deposit/utils/constants.py
+++ b/ethstaker_deposit/utils/constants.py
@@ -1,7 +1,6 @@
 import os
 from typing import (
     Dict,
-    List,
 )
 
 
@@ -33,7 +32,7 @@ DEFAULT_PARTIAL_DEPOSIT_FOLDER_NAME = 'partial_deposits'
 INTL_CONTENT_PATH = os.path.join('ethstaker_deposit', 'intl')
 
 
-def _add_index_to_options(d: Dict[str, List[str]]) -> Dict[str, List[str]]:
+def _add_index_to_options(d: Dict[str, list[str]]) -> Dict[str, list[str]]:
     '''
     Adds the (1 indexed) index (in the dict) to the first element of value list.
     eg. {'en': ['English', 'en']} -> {'en': ['1. English', '1', 'English', 'en']}

--- a/ethstaker_deposit/utils/intl.py
+++ b/ethstaker_deposit/utils/intl.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Dict,
     Iterable,
-    List,
     Mapping,
     Sequence,
 )
@@ -37,7 +36,7 @@ def _get_from_dict(dataDict: Dict[str, Any], mapList: Iterable[str]) -> str:
         raise KeyError('The provided params (%s) were incomplete.' % mapList)
 
 
-def load_text(params: List[str], file_path: str = '', func: str = '', lang: str = '') -> str:
+def load_text(params: list[str], file_path: str = '', func: str = '', lang: str = '') -> str:
     '''
     Determine and return the appropriate internationalisation text for a given set of `params`.
     '''
@@ -75,7 +74,7 @@ def load_text(params: List[str], file_path: str = '', func: str = '', lang: str 
         return load_text(params, file_path, func, 'en')
 
 
-def get_first_options(options: Mapping[str, Sequence[str]]) -> List[str]:
+def get_first_options(options: Mapping[str, Sequence[str]]) -> list[str]:
     '''
     Returns the first `option` in the values of the `options` dict.
     '''


### PR DESCRIPTION
## Changes

Python 3.9 introduced `list` type, no longer requiring `typing.List`. This PR changes all `List` to `list`, and removes the `typing.List` imports

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes
- [ ] No
