### PR TITLE
Clear clipboard of the mnemonic

### DIFF
--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -17,7 +17,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--withdrawal_address`**: The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.
 
-- **`--pbkdf2`**: Will use pbkdf2 key derivation instead of scrypt for generated keystore files as defined in [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335#decryption-key). This can be a good alternative if you intend to work with a large number of keys, as it can improve performance however it is less secure. You should only use this option if you understand the associated risks and have familiarity with encryption.
+- **`--pbkdf2`**: Will use pbkdf2 key encryption instead of scrypt for generated keystore files as defined in [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335#decryption-key). This can be a good alternative if you intend to work with a large number of keys, as it can improve performance. pbkdf2 encryption is, however, less secure than scrypt. You should only use this option if you understand the associated risks and have familiarity with encryption.
 
 - **`--folder`**: The folder where keystore and deposit data files will be saved.
 
@@ -31,3 +31,7 @@ A successful call to this command will result in one or many [keystore files](ke
 ```sh
 ./deposit new-mnemonic
 ```
+
+## Note
+
+The newly generated mnemonic **must** be written down, on a piece of paper or transferred to steel. The clipboard is cleared when this command finishes. If the mnemonic is lost and the validator does not have a withdrawal address, funds **cannot** be recovered.

--- a/ethstaker_deposit/cli/existing_mnemonic.py
+++ b/ethstaker_deposit/cli/existing_mnemonic.py
@@ -1,4 +1,5 @@
 import click
+import pyperclip
 from typing import (
     Any,
     Callable,
@@ -85,4 +86,9 @@ def validate_mnemonic(ctx: click.Context, param: Any, mnemonic: str) -> str:
 def existing_mnemonic(ctx: click.Context, mnemonic: str, mnemonic_password: str, **kwargs: Any) -> None:
     ctx.obj = {} if ctx.obj is None else ctx.obj  # Create a new ctx.obj if it doesn't exist
     ctx.obj.update({'mnemonic': mnemonic, 'mnemonic_password': mnemonic_password})
+    # Clear clipboard
+    try:  # Failing this on headless Linux is expected
+        pyperclip.copy(' ')
+    except Exception:
+        pass
     ctx.forward(generate_keys)

--- a/ethstaker_deposit/cli/new_mnemonic.py
+++ b/ethstaker_deposit/cli/new_mnemonic.py
@@ -1,4 +1,5 @@
 import click
+import pyperclip
 from typing import (
     Any,
 )
@@ -58,6 +59,11 @@ def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> N
         click.clear()
         test_mnemonic = click.prompt(load_text(['msg_mnemonic_retype_prompt']) + '\n\n')
     click.clear()
+    # Clear clipboard
+    try:  # Failing this on headless Linux is expected
+        pyperclip.copy(' ')
+    except Exception:
+        pass
     # Do NOT use mnemonic_password.
     ctx.obj = {'mnemonic': mnemonic, 'mnemonic_password': ''}
     ctx.params['validator_start_index'] = 0

--- a/ethstaker_deposit/intl/en/cli/new_mnemonic.json
+++ b/ethstaker_deposit/intl/en/cli/new_mnemonic.json
@@ -10,6 +10,6 @@
         },
         "msg_mnemonic_presentation": "This is your mnemonic (seed phrase). Write it down and store it safely. It is the ONLY way to retrieve your deposit.",
         "msg_press_any_key": "Press any key when you have written down your mnemonic.",
-        "msg_mnemonic_retype_prompt": "Please type your mnemonic (separated by spaces) to confirm you have written it down. Note: you only need to enter the first 4 letters of each word if you'd prefer."
+        "msg_mnemonic_retype_prompt": "Please type your mnemonic (separated by spaces) to confirm you have written it down. You MUST write the mnemonic down, as the clipboard will be cleared after this step. Note: you only need to enter the first 4 letters of each word if you'd prefer."
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "eth-typing",
     "eth-utils",
     "pycryptodome",
+    "pyperclip",
     "py-ecc",
     "ssz"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -245,6 +245,8 @@ pycryptodome==3.20.0 \
     --hash=sha256:f35d6cee81fa145333137009d9c8ba90951d7d77b67c79cbe5f03c7eb74d8fe2 \
     --hash=sha256:f47888542a0633baff535a04726948e876bf1ed880fddb7c10a736fa99146ab3 \
     --hash=sha256:fb3b87461fa35afa19c971b0a2b7456a7b1db7b4eba9a8424666104925b78128
+pyperclip==1.9.0 \
+    --hash=sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310
 pyrsistent==0.16.1 \
     --hash=sha256:aa2ae1c2e496f4d6777f869ea5de7166a8ccb9c2e06ebcf6c7ff1b670c98c5ef
 six==1.16.0 \


### PR DESCRIPTION
Partially addresses #32  

## Changes

Use `pyperclip`, which works on macOS, Linux and Windows, to set the clipboard to a space character after user is done inputting data

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes
- [ ] No

## Remarks

This introduces some host dependencies. Notably on Linux, clipboard mechanisms only exist if a window manager is present. So as to not bomb out on headless Linux, the code is in a `try: except:`

"On Windows, no additional modules are needed.

On Mac, this module makes use of the pbcopy and pbpaste commands, which should come with the os.

On Linux, this module makes use of the xclip or xsel commands, which should come with the os. Otherwise run “sudo apt-get install xclip” or “sudo apt-get install xsel” (Note: xsel does not always seem to work.)"