### PR TITLE
Fix coverage data uploads, update comment.yml workflow to fail open.

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -22,15 +22,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Comment on PR'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./issue_number'));
-            await github.issues.createComment({
+            const issueNumberPath = './issue_number'
+            if (!fs.existsSync(issueNumberPath)) {
+              console.log("Coverage artifacts were not downloaded, succeeding early");
+              return;
+            }
+            var issueNumber = Number(fs.readFileSync(issueNumberPath));
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issue_number,
+              issue_number: issueNumber,
               body: fs.readFileSync('./coverage-text-report').toString()
             });

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -69,6 +69,8 @@ jobs:
           name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}
           retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
   coverage-combine:
     needs: ci-runner
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
First, update the main-branch task to implement what @yorickdowne attempted in https://github.com/eth-educators/ethstaker-deposit-cli/pull/128
Instead of skipping the comment job, it simply succeeds early:

![image](https://github.com/user-attachments/assets/b97b0c57-092e-49f4-8059-55479dad89d8)


Second, fix the data uploads which inexplicably stopped uploading hidden files without the `include-hidden-files` flag.

Finally, set `if-no-files-found: error` so that the test jobs fail if no coverage report is uploaded- otherwise, because the main-branch task fails open, we may see false negatives, which we really don't want.

A version bump for github-script is included out of fastidiousness.

