### PR TITLE
capping max deposit amount for partial to 2048

### DIFF
--- a/ethstaker_deposit/cli/generate_bls_to_execution_change.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change.py
@@ -26,7 +26,7 @@ from ethstaker_deposit.utils.validation import (
 )
 from ethstaker_deposit.utils.constants import (
     DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME,
-    MAX_DEPOSIT_AMOUNT,
+    MIN_ACTIVATION_AMOUNT,
 )
 from ethstaker_deposit.utils.click import (
     captive_prompt_callback,
@@ -182,7 +182,7 @@ def generate_bls_to_execution_change(
         )
 
     num_validators = len(validator_indices)
-    amounts = [MAX_DEPOSIT_AMOUNT] * num_validators
+    amounts = [MIN_ACTIVATION_AMOUNT] * num_validators
 
     credentials = CredentialList.from_mnemonic(
         mnemonic=mnemonic,

--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -18,8 +18,8 @@ from ethstaker_deposit.utils.validation import (
     validate_withdrawal_address,
 )
 from ethstaker_deposit.utils.constants import (
-    MAX_DEPOSIT_AMOUNT,
     DEFAULT_VALIDATOR_KEYS_FOLDER_NAME,
+    MIN_ACTIVATION_AMOUNT,
 )
 from ethstaker_deposit.utils.ascii_art import RHINO_0
 from ethstaker_deposit.utils.click import (
@@ -127,7 +127,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
                   withdrawal_address: HexAddress, pbkdf2: bool, **kwargs: Any) -> None:
     mnemonic = ctx.obj['mnemonic']
     mnemonic_password = ctx.obj['mnemonic_password']
-    amounts = [MAX_DEPOSIT_AMOUNT] * num_validators
+    amounts = [MIN_ACTIVATION_AMOUNT] * num_validators
     folder = os.path.join(folder, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     chain_setting = get_chain_setting(chain)
     if not os.path.exists(folder):

--- a/ethstaker_deposit/intl/en/utils/validation.json
+++ b/ethstaker_deposit/intl/en/utils/validation.json
@@ -21,7 +21,7 @@
         "err_invalid_amount": "Invalid amount provided. Please provide a value of at least 1 ether of how much you wish to deposit.",
         "err_not_gwei_denomination": "Invalid amount provided. Please provide a value can not have precision beyond 1 gwei.",
         "err_min_deposit": "Invalid amount provided. Please provide a value of at least 1 ether.",
-        "err_max_deposit": "Invalid amount provided. Value is too large. Please provide a lesser amount."
+        "err_max_deposit": "Invalid amount provided. The max deposit amount is 2048 ether. Please provide a lesser amount."
     },
     "validate_bls_withdrawal_credentials": {
         "err_is_already_01_form": "The given withdrawal credentials is already in 0x01 form. Have you already set the withdrawal address?",

--- a/ethstaker_deposit/utils/constants.py
+++ b/ethstaker_deposit/utils/constants.py
@@ -17,9 +17,8 @@ COMPOUNDING_WITHDRAWAL_PREFIX = bytes.fromhex('02')
 ETH2GWEI = 10 ** 9
 # TODO: check if user will can deposit a new validator with more than 32 and 0x02 credentials or 0x00 and 0x01 only
 MIN_DEPOSIT_AMOUNT = 2 ** 0 * ETH2GWEI
-MAX_DEPOSIT_AMOUNT = 2 ** 5 * ETH2GWEI
-# Deposit max https://github.com/ethereum/consensus-specs/blob/dev/solidity_deposit_contract/deposit_contract.sol#L116
-GWEI_DEPOSIT_LIMIT = 2**64 - 1
+MIN_ACTIVATION_AMOUNT = 2 ** 5 * ETH2GWEI
+MAX_DEPOSIT_AMOUNT = 2 ** 11 * ETH2GWEI
 
 # File/folder constants
 WORD_LISTS_PATH = os.path.join('ethstaker_deposit', 'key_handling', 'key_derivation', 'word_lists')

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -35,8 +35,8 @@ from ethstaker_deposit.utils.constants import (
     COMPOUNDING_WITHDRAWAL_PREFIX,
     ETH2GWEI,
     EXECUTION_ADDRESS_WITHDRAWAL_PREFIX,
-    GWEI_DEPOSIT_LIMIT,
     MIN_DEPOSIT_AMOUNT,
+    MAX_DEPOSIT_AMOUNT,
 )
 from ethstaker_deposit.utils.crypto import SHA256
 from ethstaker_deposit.settings import BaseChainSetting
@@ -110,7 +110,7 @@ def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential =
         return False
 
     # Verify deposit amount
-    if not MIN_DEPOSIT_AMOUNT <= amount <= GWEI_DEPOSIT_LIMIT:
+    if not MIN_DEPOSIT_AMOUNT <= amount <= MAX_DEPOSIT_AMOUNT:
         return False
 
     # Verify deposit signature && pubkey
@@ -173,7 +173,7 @@ def validate_withdrawal_address(cts: click.Context, param: Any, address: str, re
 
 def validate_partial_deposit_amount(amount: str) -> int:
     '''
-    Verifies that `amount` is a valid gwei denomination and 1 ether <= amount <= GWEI_DEPOSIT_LIMIT gwei
+    Verifies that `amount` is a valid gwei denomination and 1 ether <= amount <= MAX_DEPOSIT_AMOUNT gwei
     Amount is expected to be in ether and the returned value will be converted to gwei and represented as an int
     '''
     try:
@@ -186,7 +186,7 @@ def validate_partial_deposit_amount(amount: str) -> int:
         if amount_gwei < 1 * ETH2GWEI:
             raise ValidationError(load_text(['err_min_deposit']))
 
-        if amount_gwei > GWEI_DEPOSIT_LIMIT:
+        if amount_gwei > MAX_DEPOSIT_AMOUNT:
             raise ValidationError(load_text(['err_max_deposit']))
 
         return int(amount_gwei)

--- a/tests/test_cli/test_partial_deposit.py
+++ b/tests/test_cli/test_partial_deposit.py
@@ -23,7 +23,7 @@ from .helpers import clean_folder, clean_key_folder, clean_partial_deposit_folde
         ("32"),
         ("1"),
         ("432.123456789"),
-        ("18446744073.709551615"),
+        ("2048"),
     ]
 )
 def test_partial_deposit(amount: str) -> None:

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -59,9 +59,9 @@ def test_validate_int_range(num: Any, low: int, high: int, valid: bool) -> None:
         ('1.000000001', True),
         ('1.0000000001', False),
         ('32', True),
-        ('18446744073.709551615', True),
-        ('18446744073.709551616', False),
-        ('18446744073.7095516151', False),
+        ('2048', True),
+        ('2048.000000001', False),
+        ('2048.0000000001', False),
         ('a', False),
         (' ', False)
     ]


### PR DESCRIPTION
## Changes

Updating the `--amount` validation to no longer cap the value to what the smart contract supports (2**64 - 1) but to 2048 ether, a more realistic value

## Types of changes
maintenance

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

I discussed with Remy and documentation will be handled in #140 
