### PR TITLE
Use withdrawal address instead of execution address and rework parts around it

### DIFF
--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -19,7 +19,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 - **`--keystore_password`**: The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. <span class="warning"></span>
 
-- **`--withdrawal_address`**: The Ethereum execution address for validator withdrawals.
+- **`--withdrawal_address`**: The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.
 
 - **`--pbkdf2`**: Will use pbkdf2 key derivation instead of scrypt for generated keystore files as defined in [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335#decryption-key). This can be a good alternative if you intend to work with a large number of keys, as it can improve performance however it is less secure. You should only use this option if you understand the associated risks and have familiarity with encryption.
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -21,7 +21,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_withdrawal_credentials_list`**: A list of the old BLS withdrawal credentials of the given validator(s). It is for confirming you are using the correct keys. Split multiple items with whitespaces or commas.
 
-- **`--withdrawal_address`**: If this field is set and valid, the given Ethereum execution address will be used to create the withdrawal credentials. Otherwise it will generate withdrawal credentials with the mnemonic-derived withdrawal public key.
+- **`--withdrawal_address`**: The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.
 
 - **`--devnet_chain_setting`**: The custom chain setting of a devnet or testnet. Note that it will override your `--chain` choice. This should be a JSON string containing an object with the following keys: network_name, genesis_fork_version, exit_fork_version and genesis_validator_root.
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -19,7 +19,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 - **`--validator_index`**: The validator index corresponding to the provided keystore.
 
-- **`--withdrawal_address`**: Ethereum execution address in hexadecimal encoded form that you wish to set as your withdrawal credentials.
+- **`--withdrawal_address`**: The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.
 
 - **`--output_folder`**: The folder path for the `bls_to_execution_change_keystore_signature-*` JSON file.
 

--- a/docs/src/landing.md
+++ b/docs/src/landing.md
@@ -46,7 +46,7 @@ If there is a specific command you would like to understand more, please choose 
 
 - **[existing-mnemonic](existing_mnemonic.md)**: Provide a mnemonic to regenerate validator keys or create new ones.
 
-- **[generate-bls-to-execution-change](generate_bls_to_execution_change.md)**: Update your withdrawal credentials of existing validators. It is **required** to have the corresponding mnemonic.
+- **[generate-bls-to-execution-change](generate_bls_to_execution_change.md)**: Add a withdrawal address to a validator that does not currently have one. It is **required** to have the corresponding mnemonic.
 
 - **[generate-bls-to-execution-change-keystore](generate_bls_to_execution_change_keystore.md)**: Sign an update withdrawal credentials message using your validator keystore.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -15,7 +15,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--keystore_password`**: The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. <span class="warning"></span>
 
-- **`--withdrawal_address`**: The Ethereum execution address for validator withdrawals.
+- **`--withdrawal_address`**: The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.
 
 - **`--pbkdf2`**: Will use pbkdf2 key derivation instead of scrypt for generated keystore files as defined in [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335#decryption-key). This can be a good alternative if you intend to work with a large number of keys, as it can improve performance however it is less secure. You should only use this option if you understand the associated risks and have familiarity with encryption.
 

--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -18,17 +18,17 @@ from ethstaker_deposit.utils.ssz import (
 def bls_to_execution_change_keystore_generation(
         chain_setting: BaseChainSetting,
         signing_key: int,
-        execution_address: HexAddress,
+        withdrawal_address: HexAddress,
         validator_index: int) -> SignedBLSToExecutionChangeKeystore:
-    if execution_address is None:
-        raise ValueError("The execution address should NOT be empty.")
+    if withdrawal_address is None:
+        raise ValueError("The withdrawal address should NOT be empty.")
     if chain_setting.GENESIS_VALIDATORS_ROOT is None:
         raise ValidationError("The genesis validators root should NOT be empty "
                               "for this chain to obtain the BLS to execution change.")
 
     message = BLSToExecutionChangeKeystore(  # type: ignore[no-untyped-call]
         validator_index=validator_index,
-        to_execution_address=to_canonical_address(execution_address),
+        to_execution_address=to_canonical_address(withdrawal_address),
     )
     domain = compute_bls_to_execution_change_keystore_domain(
         fork_version=chain_setting.GENESIS_FORK_VERSION,

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -142,7 +142,7 @@ def generate_bls_to_execution_change_keystore(
         chain_setting=chain_setting,
         signing_key=signing_key,
         validator_index=validator_index,
-        execution_address=withdrawal_address,
+        withdrawal_address=withdrawal_address,
     )
 
     folder = os.path.join(output_folder, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -172,7 +172,7 @@ class Credential:
 
     def get_bls_to_execution_change(self, validator_index: int) -> SignedBLSToExecutionChange:
         if self.withdrawal_address is None:
-            raise ValueError("The execution address should NOT be empty.")
+            raise ValueError("The withdrawal address should NOT be empty.")
         if self.chain_setting.GENESIS_VALIDATORS_ROOT is None:
             raise ValidationError("The genesis validators root should NOT be empty "
                                   "for this chain to obtain the BLS to execution change.")

--- a/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change.json
+++ b/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change.json
@@ -4,9 +4,9 @@
             "help": "Generating the SignedBLSToExecutionChange data to enable withdrawals on Ethereum Beacon Chain."
         },
         "arg_withdrawal_address": {
-            "help": "The 20-byte Ethereum execution address that will be used in withdrawal",
-            "prompt": "Please enter the 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
-            "confirm": "Repeat your execution address for confirmation.",
+            "help": "The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.",
+            "prompt": "Please enter the withdrawal address. Note that you CANNOT change it once you have set it on chain.",
+            "confirm": "Repeat your withdrawal address for confirmation.",
             "mismatch": "Error: the two entered values do not match. Please type again."
         },
         "arg_devnet_chain_setting": {

--- a/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change_keystore.json
+++ b/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change_keystore.json
@@ -4,9 +4,9 @@
           "help": "Generating the SignedBLSToExecutionChange data to enable withdrawals on Ethereum Beacon Chain."
       },
       "arg_withdrawal_address": {
-          "help": "The 20-byte Ethereum execution address that will be used in withdrawal",
-          "prompt": "Please enter the 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
-          "confirm": "Repeat your execution address for confirmation.",
+          "help": "The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.",
+          "prompt": "Please enter the withdrawal address. Note that you CANNOT change it once you have set it on chain.",
+          "confirm": "Repeat your withdrawal address for confirmation.",
           "mismatch": "Error: the two entered values do not match. Please type again."
       },
       "arg_devnet_chain_setting": {

--- a/ethstaker_deposit/intl/en/cli/generate_keys.json
+++ b/ethstaker_deposit/intl/en/cli/generate_keys.json
@@ -18,9 +18,9 @@
             "mismatch": "Error: the two entered values do not match. Please type again."
         },
         "arg_withdrawal_address": {
-            "help": "The 20-byte Ethereum execution address that will be used in withdrawal",
-            "prompt": "Please enter the optional 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
-            "confirm": "Repeat your execution address for confirmation.",
+            "help": "The Ethereum address that will be used in withdrawal. It typically starts with '0x' followed by 40 hexadecimal characters. Please make sure you have full control over the address you choose here. Once you set a withdrawal address on chain, it cannot be changed.",
+            "prompt": "Please enter the optional withdrawal address. Note that you CANNOT change it once you have set it on chain.",
+            "confirm": "Repeat your withdrawal address for confirmation.",
             "mismatch": "Error: the two entered values do not match. Please type again."
         },
         "arg_pbkdf2": {

--- a/ethstaker_deposit/intl/en/cli/partial_deposit.json
+++ b/ethstaker_deposit/intl/en/cli/partial_deposit.json
@@ -26,7 +26,7 @@
       "arg_withdrawal_address": {
           "help": "The withdrawal address of the validator. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command.",
           "confirm": "Repeat the withdrawal address for confirmation.",
-          "prompt": "Please enter the 20-byte execution address withdrawal credentials of the validator. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command."
+          "prompt": "Please enter the withdrawal address. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command."
       },
       "arg_devnet_chain_setting": {
           "help": "[DEVNET ONLY] Set specific GENESIS_FORK_VERSION value. This should be a JSON string containing an object with the following keys: network_name, genesis_fork_version, exit_fork_version and genesis_validator_root. It should be similar to what you can find in settings.py. This will override any selected chain."

--- a/ethstaker_deposit/intl/en/utils/validation.json
+++ b/ethstaker_deposit/intl/en/utils/validation.json
@@ -14,10 +14,10 @@
         "err_invalid_choice": "That is not one of the valid choices. Please retype your choice."
     },
     "validate_withdrawal_address": {
-        "err_invalid_ECDSA_hex_addr": "The given execution address is not in hexadecimal encoded form.",
-        "err_invalid_ECDSA_hex_addr_checksum": "The given execution address is not in checksum form.",
+        "err_invalid_ECDSA_hex_addr": "The given withdrawal address is not in hexadecimal encoded form.",
+        "err_invalid_ECDSA_hex_addr_checksum": "The given withdrawal address is not in checksum form.",
         "err_missing_address": "An address must be provided",
-        "msg_ECDSA_hex_addr_withdrawal": "**[Warning] you are setting an execution address as your withdrawal address. Please ensure that you have control over this address.**"
+        "msg_ECDSA_hex_addr_withdrawal": "**[Warning] you are setting a withdrawal address. Please ensure that you have full control over this address.**"
     },
     "validate_partial_deposit_amount": {
         "err_invalid_amount": "Invalid amount provided. Please provide a value of at least 1 ether of how much you wish to deposit.",


### PR DESCRIPTION
Fixes #133 

## Changes

- Rework the documentation around the *execution address* to simplify it and mostly replace it with the *withdrawal address* term.
- Minor updates to code that still used the *execution address* term.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [X] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

Documentation updates are included in this PR.

#### Requires explanation in Release Notes

- [ ] Yes
- [X] No

_If yes, fill in the details here. Remove if not applicable._

