### PR TITLE
Use a different asset name for Ubuntu on arm64 binary assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r build_configs/windows/requirements.txt
       - name: Build with build.spec (Linux amd64)
-        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu-') && !contains(matrix.os, 'arm') }}
         run: |
           export BUILD_FILE_NAME=ethstaker_deposit-cli-${SHORT_SHA}-linux-amd64
+          echo "BUILD_FILE_NAME=${BUILD_FILE_NAME}" >> "$GITHUB_ENV"
+          mkdir ${BUILD_FILE_NAME}
+          pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec
+      - name: Build with build.spec (Linux arm64)
+        if: ${{ startsWith(matrix.os, 'ubuntu-') && contains(matrix.os, 'arm') }}
+        run: |
+          export BUILD_FILE_NAME=ethstaker_deposit-cli-${SHORT_SHA}-linux-arm64
           echo "BUILD_FILE_NAME=${BUILD_FILE_NAME}" >> "$GITHUB_ENV"
           mkdir ${BUILD_FILE_NAME}
           pyinstaller --distpath ./${BUILD_FILE_NAME} ./build_configs/linux/build.spec


### PR DESCRIPTION
Fixes #152 

## Changes

- Rework the build workflow to create assets with a different name on Ubuntu arm64 compared to Ubuntu amd64. See [a recent build run](https://github.com/eth-educators/ethstaker-deposit-cli/actions/runs/10887913346) to notice that they are currently both named `amd64`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

This will be tested during the next test release which should be in a few days.

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [ ] Yes
- [X] No

