### PR TITLE
Clear scrollback

### DIFF
--- a/ethstaker_deposit/cli/generate_bls_to_execution_change.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change.py
@@ -38,6 +38,7 @@ from ethstaker_deposit.utils.intl import (
     closest_match,
     load_text,
 )
+from ethstaker_deposit.utils.terminal import clear_terminal
 from ethstaker_deposit.settings import (
     MAINNET,
     ALL_CHAIN_KEYS,
@@ -208,7 +209,7 @@ def generate_bls_to_execution_change(
     if not json_file_validation_result:
         raise ValidationError(load_text(['err_verify_btec']))
 
-    click.clear()
+    clear_terminal()
     click.echo(OWL_0)
     click.echo(load_text(['msg_creation_success']) + str(bls_to_execution_changes_folder))
 

--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -33,6 +33,7 @@ from ethstaker_deposit.utils.intl import (
     closest_match,
     load_text,
 )
+from ethstaker_deposit.utils.terminal import clear_terminal
 from ethstaker_deposit.settings import (
     MAINNET,
     ALL_CHAIN_KEYS,
@@ -140,7 +141,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
 
     if not os.path.exists(folder):
         os.mkdir(folder)
-    click.clear()
+    clear_terminal()
     click.echo(RHINO_0)
     click.echo(load_text(['msg_key_creation']))
     credentials = CredentialList.from_mnemonic(

--- a/ethstaker_deposit/cli/new_mnemonic.py
+++ b/ethstaker_deposit/cli/new_mnemonic.py
@@ -22,6 +22,7 @@ from ethstaker_deposit.utils.intl import (
     load_text,
     get_first_options,
 )
+from ethstaker_deposit.utils.terminal import clear_terminal
 
 from .generate_keys import (
     generate_keys,
@@ -51,14 +52,14 @@ def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> N
     mnemonic = get_mnemonic(language=mnemonic_language, words_path=WORD_LISTS_PATH)
     test_mnemonic = ''
     while mnemonic != reconstruct_mnemonic(test_mnemonic, WORD_LISTS_PATH):
-        click.clear()
+        clear_terminal()
         click.echo(load_text(['msg_mnemonic_presentation']))
         click.echo('\n\n%s\n\n' % mnemonic)
         click.pause(load_text(['msg_press_any_key']))
 
-        click.clear()
+        clear_terminal()
         test_mnemonic = click.prompt(load_text(['msg_mnemonic_retype_prompt']) + '\n\n')
-    click.clear()
+    clear_terminal()
     # Clear clipboard
     try:  # Failing this on headless Linux is expected
         pyperclip.copy(' ')

--- a/ethstaker_deposit/utils/terminal.py
+++ b/ethstaker_deposit/utils/terminal.py
@@ -1,0 +1,27 @@
+import subprocess
+import os
+import sys
+import shutil
+import click
+
+
+def clear_terminal() -> None:
+    if sys.platform == 'win32':
+        # Special-case for asyncio pytest on Windows
+        if os.getenv("IS_ASYNC_TEST") == "1":
+            click.clear()
+        elif shutil.which('clear'):
+            subprocess.call(['clear'])
+        else:
+            subprocess.call('cls', shell=True)
+    elif sys.platform == 'linux' or sys.platform == 'darwin':
+        if shutil.which('tput'):
+            subprocess.call(['tput', 'reset'])
+        elif shutil.which('reset'):
+            subprocess.call(['reset'])
+        elif shutil.which('clear'):
+            subprocess.call(['clear'])
+        else:
+            click.clear()
+    else:
+        click.clear()

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import pytest
+import inspect
 from click.testing import CliRunner
 
 from eth_utils import decode_hex
@@ -18,6 +19,14 @@ from ethstaker_deposit.utils.constants import (
 )
 from ethstaker_deposit.utils.intl import load_text
 from .helpers import clean_key_folder, get_permissions, get_uuid
+
+
+@pytest.fixture(autouse=True)
+def check_async(request):
+    if inspect.iscoroutinefunction(request.node.obj):
+        os.environ['IS_ASYNC_TEST'] = '1'
+    else:
+        os.environ['IS_ASYNC_TEST'] = '0'
 
 
 def test_new_mnemonic_bls_withdrawal(monkeypatch) -> None:


### PR DESCRIPTION
Resolves #32 , together with #130

## Changes

Instead of `click.clear()` use `cls` or `tput reset`, depending on OS. This clears the scrollback of the terminal, at least on "modern" versions of Windows, Linux and macOS

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
