### PR TITLE
Remove `LD_LIBRARY_PATH` on Linux when calling `tput`

### DIFF
--- a/ethstaker_deposit/utils/terminal.py
+++ b/ethstaker_deposit/utils/terminal.py
@@ -6,21 +6,26 @@ import click
 
 
 def clear_terminal() -> None:
+    # We bundle libtinfo via pyinstaller, which messes with the system tput.
+    # Remove LD_LIBRARY_PATH just for subprocess.run()
+    if sys.platform == 'linux':
+        clean_env = os.environ.copy()
+        clean_env.pop('LD_LIBRARY_PATH', None)
     if sys.platform == 'win32':
         # Special-case for asyncio pytest on Windows
         if os.getenv("IS_ASYNC_TEST") == "1":
             click.clear()
         elif shutil.which('clear'):
-            subprocess.call(['clear'])
+            subprocess.run(['clear'])
         else:
-            subprocess.call('cls', shell=True)
+            subprocess.run('cls', shell=True)
     elif sys.platform == 'linux' or sys.platform == 'darwin':
         if shutil.which('tput'):
-            subprocess.call(['tput', 'reset'])
+            subprocess.run(['tput', 'reset'], env=clean_env)
         elif shutil.which('reset'):
-            subprocess.call(['reset'])
+            subprocess.run(['reset'], env=clean_env)
         elif shutil.which('clear'):
-            subprocess.call(['clear'])
+            subprocess.run(['clear'], env=clean_env)
         else:
             click.clear()
     else:


### PR DESCRIPTION
Fixes  #163 

## Changes

Remove `LD_LIBRARY_PATH` for the call to `tput`, so system libraries are used. Otherwise, the bundled `libtinfo.so.6` can cause issues.

Note `libtinfo.so.6` was present all along, but only became an issue once we started calling `tput`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### Notes on testing

We will need to test the created binary on Ubuntu 20, 22, 24; Debian 11, 12. This is manual alas.
