### PR TITLE
Use sys.exit instead of exit

### DIFF
--- a/ethstaker_deposit/cli/exit_transaction_keystore.py
+++ b/ethstaker_deposit/cli/exit_transaction_keystore.py
@@ -1,5 +1,6 @@
 import click
 import os
+import sys
 import time
 from typing import Any, Optional
 
@@ -117,7 +118,7 @@ def exit_transaction_keystore(
         secret_bytes = keystore.decrypt(keystore_password)
     except ValueError:
         click.echo(load_text(['arg_exit_transaction_keystore_keystore_password', 'mismatch']), err=True)
-        exit(1)
+        sys.exit(1)
 
     signing_key = int.from_bytes(secret_bytes, 'big')
 

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -1,6 +1,7 @@
-import os
-import time
 import click
+import os
+import sys
+import time
 from typing import Any, Optional
 
 from eth_typing import HexAddress
@@ -132,7 +133,7 @@ def generate_bls_to_execution_change_keystore(
         secret_bytes = keystore.decrypt(keystore_password)
     except ValueError:
         click.echo(load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'mismatch']), err=True)
-        exit(1)
+        sys.exit(1)
 
     signing_key = int.from_bytes(secret_bytes, 'big')
 

--- a/ethstaker_deposit/cli/partial_deposit.py
+++ b/ethstaker_deposit/cli/partial_deposit.py
@@ -1,6 +1,7 @@
 import json
 import click
 import os
+import sys
 import time
 
 from eth_typing import HexAddress
@@ -139,7 +140,7 @@ def partial_deposit(
         secret_bytes = keystore.decrypt(keystore_password)
     except ValueError:
         click.echo(load_text(['arg_partial_deposit_keystore_password', 'mismatch']), err=True)
-        exit(1)
+        sys.exit(1)
 
     signing_key = int.from_bytes(secret_bytes, 'big')
 

--- a/ethstaker_deposit/cli/test_keystore.py
+++ b/ethstaker_deposit/cli/test_keystore.py
@@ -1,4 +1,5 @@
 import click
+import sys
 from typing import Any
 
 from ethstaker_deposit.key_handling.keystore import Keystore
@@ -54,7 +55,7 @@ def test_keystore(
         keystore.decrypt(keystore_password)
     except ValueError:
         click.echo(load_text(['arg_test_keystore_keystore_password', 'mismatch']), err=True)
-        exit(1)
+        sys.exit(1)
 
     click.echo(load_text(['msg_verification_success']))
     if not config.non_interactive:


### PR DESCRIPTION
**What I did**
Replaced usages of `exit` with `sys.exit` as was the case in `deposit.py`

**Related issue**
FIxes #175 
