### PR TITLE
Adding missing bls_keystore documentation

### DIFF
--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -31,5 +31,5 @@ A successful call to this command will result in one [BLS to Execution Change Ke
 ## Example Usage
 
 ```sh
-./deposit generate-bls-to-execution-change
+./deposit generate-bls-to-execution-change-keystore
 ```

--- a/docs/src/quick_setup.md
+++ b/docs/src/quick_setup.md
@@ -57,6 +57,8 @@ Determine which command best suites what you would like to accomplish:
 
 - **[generate-bls-to-execution-change](generate_bls_to_execution_change.md)**: Update your withdrawal credentials of existing validators. It is **required** to have the corresponding mnemonic.
 
+- **[generate-bls-to-execution-change-keystore](generate_bls_to_execution_change_keystore.md)**: Sign an update withdrawal credentials message using your validator keystore.
+
 - **[exit-transaction-keystore](exit_transaction_keystore.md)**: Generate an exit message using the keystore of your validators.
 
 - **[exit-transaction-mnemonic](exit_transaction_mnemonic.md)**: Generate an exit message using the mnemonic of your validators.


### PR DESCRIPTION
**What I did**
There was missing or incorrect documentation with the `generate-bls-to-execution-change-keystore` command that caused confusion.

