### PR TITLE
Pin dockerfile image with sha256 hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim-bookworm
+# This image is from python:3.12-slim-bookworm
+FROM python@sha256:af4e85f1cac90dd3771e47292ea7c8a9830abfabbe4faa5c53f158854c2e819d
 
 WORKDIR /app
 


### PR DESCRIPTION
**What I did**

Pinned dockerfile image with sha256 hash. You can compare it with what's available on the hub at https://hub.docker.com/layers/library/python/3.12-slim-bookworm/images/sha256-d2ead4f6f2ac4b88e44b45a06caea68ad3e2280c0028afcf136e9edfe28c2346?context=explore

**Related issue**

Part of the fix to #181 