### PR TITLE
bugfix: Use all clearing methods for linux/darwin

### DIFF
--- a/ethstaker_deposit/utils/terminal.py
+++ b/ethstaker_deposit/utils/terminal.py
@@ -27,13 +27,13 @@ def clear_terminal() -> None:
         else:
             subprocess.run('cls', shell=True)
     elif sys.platform == 'linux' or sys.platform == 'darwin':
-        if shutil.which('tput'):
-            subprocess.run(['tput', 'reset'], env=clean_env)
-        elif shutil.which('reset'):
-            subprocess.run(['reset'], env=clean_env)
-        elif shutil.which('clear'):
+        if shutil.which('clear'):
             subprocess.run(['clear'], env=clean_env)
         else:
             click.clear()
+        if shutil.which('tput'):
+            subprocess.run(['tput', 'reset'], env=clean_env)
+        if shutil.which('reset'):
+            subprocess.run(['reset'], env=clean_env)
     else:
         click.clear()


### PR DESCRIPTION
**What I did**
Changed the terminal clear logic to use all methods as suggested by ToB during the call. 

Two things to note:
- I noticed no benefit between this versus changing the ordering. With this change, there is a noticeable lag when clearing the terminal. Unless we have a use case for this I would rather change ordering as originally suggestetd.
- When a clear is attempted in iterm2, it does not happen automatically. Instead the user is shown a warning which can easily be ignored. I'm not aware of any 
<img width="807" alt="Screenshot 2024-10-09 at 7 10 04 PM" src="https://github.com/user-attachments/assets/d196aeb5-4c7f-4a04-8384-ee5db52983e8">
way to bypass this.


**Related issue**
Fixes #186 
