### PR TITLE
Don't return in `JITOption.__init__`

### DIFF
--- a/ethstaker_deposit/utils/click.py
+++ b/ethstaker_deposit/utils/click.py
@@ -45,7 +45,7 @@ class JITOption(click.Option):
         if isinstance(param_decls, str):
             param_decls = [_value_of(param_decls)]
 
-        return super().__init__(
+        super().__init__(
             param_decls=param_decls,
             default=_value_of(default),
             help=_value_of(help),


### PR DESCRIPTION
**What I did**

Removed the return call in `JITOption.__init__`. It is not needed and it should not be there.

**Related issue**

Part of the fixes for #187.

