### PR TITLE
Fix the comment workflow failure by checking for the coverage job success

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -27,7 +27,7 @@ jobs:
 
             core.exportVariable('COVERAGE', 'unknown');
 
-            const allJobs = await github.rest.actions.listJobsForWorkflowRun({
+            const { data: allJobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: WORKFLOW_RUN_ID,

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,6 +1,6 @@
 # Safely comment on the PR - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 name: ci-comment
-run-name: commenting on PR by ${{ github.actor }}
+run-name: ${{ github.actor }} is adding coverage report comment on PR
 on:
   workflow_run:
     workflows: [ "ci-runner" ]
@@ -16,12 +16,12 @@ jobs:
     outputs:
       coverage: ${{ steps.output.outputs.coverage }}
     steps:
-      - name: 'Get coverage job success'
+      - name: Get coverage job success
         uses: actions/github-script@v7
+        env:
+          WORKFLOW_RUN_ID: '${{ github.event.workflow_run.id }}'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          env:
-            WORKFLOW_RUN_ID: '${{ github.event.workflow_run.id }}'
           script: |
             const { WORKFLOW_RUN_ID } = process.env;
 
@@ -33,7 +33,7 @@ jobs:
               run_id: WORKFLOW_RUN_ID,
             });
 
-            for (const job in allJobs.jobs) {
+            allJobs.jobs.forEach((job) => {
               if (
                 job.name === 'coverage-combine' &&
                 job.status == 'completed' &&
@@ -41,14 +41,18 @@ jobs:
               ) {
                 core.exportVariable('COVERAGE', 'completed');
               }
-            }
-      - name: 'Output coverage status'
+            });
+      - name: Output coverage status
         id: output
         run: echo "coverage=${COVERAGE}" >> "$GITHUB_OUTPUT"
   comment:
     needs: completed-coverage
     # Runs only if we have a completed coverage job from the ci-runner workflow
     if: ${{ needs.completed-coverage.outputs.coverage == 'completed' }}
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -58,7 +62,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Comment on PR'
+      - name: Comment on PR
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,5 +1,5 @@
 # Safely comment on the PR - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-name: Comment on pull request
+name: ci-comment
 run-name: commenting on PR by ${{ github.actor }}
 on:
   workflow_run:
@@ -8,11 +8,48 @@ on:
       - completed
 
 jobs:
-  comment:
+  completed-coverage:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
+    outputs:
+      coverage: ${{ steps.output.outputs.coverage }}
+    steps:
+      - name: 'Get coverage job success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          env:
+            WORKFLOW_RUN_ID: '${{ github.event.workflow_run.id }}'
+          script: |
+            const { WORKFLOW_RUN_ID } = process.env;
+
+            core.exportVariable('COVERAGE', 'unknown');
+
+            const allJobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: WORKFLOW_RUN_ID,
+            });
+
+            for (const job in allJobs.jobs) {
+              if (
+                job.name === 'coverage-combine' &&
+                job.status == 'completed' &&
+                job.conclusion == 'success'
+              ) {
+                core.exportVariable('COVERAGE', 'completed');
+              }
+            }
+      - name: 'Output coverage status'
+        id: output
+        run: echo "coverage=${COVERAGE}" >> "$GITHUB_OUTPUT"
+  comment:
+    needs: completed-coverage
+    # Runs only if we have a completed coverage job from the ci-runner workflow
+    if: ${{ needs.completed-coverage.outputs.coverage == 'completed' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**What I did**

I changed how the comment workflow works to check for the success of the coverage-combine job on the ci-runner workflow.

**Related issue**

Fixes #156 

