### PR TITLE
Use 400 for sensitive files permissions on creation with O_EXCL flag

### DIFF
--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -13,6 +13,9 @@ from ethstaker_deposit.utils.ssz import (
     compute_signing_root,
     compute_bls_to_execution_change_keystore_domain,
 )
+from ethstaker_deposit.utils.file_handling import (
+    sensitive_opener,
+)
 
 
 def bls_to_execution_change_keystore_generation(
@@ -64,8 +67,6 @@ def export_bls_to_execution_change_keystore_json(folder: str,
         'bls_to_execution_change_keystore_signature-%s-%i.json' % (index, timestamp)
     )
 
-    with open(filefolder, 'w') as f:
+    with open(filefolder, 'w', opener=sensitive_opener) as f:
         json.dump(signed_bls_to_execution_change_keystore_json, f)
-    if os.name == 'posix':
-        os.chmod(filefolder, int('440', 8))  # Read for owner & group
     return filefolder

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -38,6 +38,9 @@ from ethstaker_deposit.utils.ssz import (
     DepositMessage,
     SignedBLSToExecutionChange,
 )
+from ethstaker_deposit.utils.file_handling import (
+    sensitive_opener,
+)
 
 
 class WithdrawalType(Enum):
@@ -364,8 +367,6 @@ class CredentialList:
                     bar.update(1)
 
         filefolder = os.path.join(folder, 'bls_to_execution_change-%i.json' % time.time())
-        with open(filefolder, 'w') as f:
+        with open(filefolder, 'w', opener=sensitive_opener) as f:
             json.dump(bls_to_execution_changes, f)
-        if os.name == 'posix':
-            os.chmod(filefolder, int('440', 8))  # Read for owner & group
         return filefolder

--- a/ethstaker_deposit/key_handling/keystore.py
+++ b/ethstaker_deposit/key_handling/keystore.py
@@ -5,7 +5,7 @@ from dataclasses import (
     field as dataclass_field
 )
 import json
-import os
+
 from py_ecc.bls import G2ProofOfPossession as bls
 from secrets import randbits
 from typing import Any, Dict, Union
@@ -20,6 +20,9 @@ from ethstaker_deposit.utils.crypto import (
 )
 from ethstaker_deposit.utils.constants import (
     UNICODE_CONTROL_CHARS,
+)
+from ethstaker_deposit.utils.file_handling import (
+    sensitive_opener,
 )
 
 hexdigits = set('0123456789abcdef')
@@ -96,10 +99,8 @@ class Keystore(BytesDataclass):
         """
         Save self as a JSON keystore.
         """
-        with open(filefolder, 'w') as f:
+        with open(filefolder, 'w', opener=sensitive_opener) as f:
             f.write(self.as_json())
-        if os.name == 'posix':
-            os.chmod(filefolder, int('440', 8))  # Read for owner & group
 
     @classmethod
     def from_json(cls, json_dict: Dict[Any, Any]) -> 'Keystore':

--- a/ethstaker_deposit/utils/deposit.py
+++ b/ethstaker_deposit/utils/deposit.py
@@ -1,11 +1,13 @@
 import json
 import os
 
+from ethstaker_deposit.utils.file_handling import (
+    sensitive_opener,
+)
+
 
 def export_deposit_data_json(folder: str, timestamp: float, deposit_data: list[dict[str, bytes]]) -> str:
     file_folder = os.path.join(folder, 'deposit_data-%i.json' % timestamp)
-    with open(file_folder, 'w') as f:
+    with open(file_folder, 'w', opener=sensitive_opener) as f:
         json.dump(deposit_data, f, default=lambda x: x.hex())
-    if os.name == 'posix':
-        os.chmod(file_folder, int('440', 8))  # Read for owner & group
     return file_folder

--- a/ethstaker_deposit/utils/exit_transaction.py
+++ b/ethstaker_deposit/utils/exit_transaction.py
@@ -10,6 +10,9 @@ from ethstaker_deposit.utils.ssz import (
     compute_signing_root,
     compute_voluntary_exit_domain,
 )
+from ethstaker_deposit.utils.file_handling import (
+    sensitive_opener,
+)
 
 
 def exit_transaction_generation(
@@ -55,8 +58,6 @@ def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit, 
         )
     )
 
-    with open(filefolder, 'w') as f:
+    with open(filefolder, 'w', opener=sensitive_opener) as f:
         json.dump(signed_exit_json, f)
-    if os.name == 'posix':
-        os.chmod(filefolder, int('440', 8))  # Read for owner & group
     return filefolder

--- a/ethstaker_deposit/utils/file_handling.py
+++ b/ethstaker_deposit/utils/file_handling.py
@@ -21,4 +21,7 @@ def sensitive_opener(path: Union[str, bytes, 'os.PathLike[Any]'], flags: int) ->
     Opener to be used with the open built-in function to correctly assign permissions to sensitive
     files when created and written to for the first time.
     """
-    return os.open(path, flags | os.O_EXCL, 0o400)
+    if os.name == 'posix':
+        return os.open(path, flags | os.O_EXCL, 0o400)
+    else:
+        return os.open(path, flags)

--- a/ethstaker_deposit/utils/file_handling.py
+++ b/ethstaker_deposit/utils/file_handling.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Any, Union
 
 
 def resource_path(relative_path: str) -> str:
@@ -13,3 +14,11 @@ def resource_path(relative_path: str) -> str:
     except Exception:
         base_path = os.path.abspath(".")
     return os.path.join(base_path, relative_path)
+
+
+def sensitive_opener(path: Union[str, bytes, 'os.PathLike[Any]'], flags: int) -> int:
+    """
+    Opener to be used with the open built-in function to correctly assign permissions to sensitive
+    files when created and written to for the first time.
+    """
+    return os.open(path, flags | os.O_EXCL, 0o400)

--- a/tests/test_cli/helpers.py
+++ b/tests/test_cli/helpers.py
@@ -60,7 +60,7 @@ def get_permissions(path: str, file_name: str) -> str:
 def verify_file_permission(os_ref, folder_path, files):
     if os_ref.name == 'posix':
         for file_name in files:
-            assert get_permissions(folder_path, file_name) == '0o440'
+            assert get_permissions(folder_path, file_name) == '0o400'
 
 
 def prepare_testing_folder(os_ref, testing_folder_name='TESTING_TEMP_FOLDER'):

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -51,7 +51,7 @@ def test_existing_mnemonic_bls_withdrawal() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -104,7 +104,7 @@ def test_existing_mnemonic_withdrawal_address() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -163,7 +163,7 @@ def test_existing_mnemonic_withdrawal_address_bad_checksum() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -289,7 +289,7 @@ async def test_script() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -338,7 +338,7 @@ async def test_script_abbreviated_mnemonic() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -393,7 +393,7 @@ def test_existing_mnemonic_custom_testnet() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -438,7 +438,7 @@ def test_existing_mnemonic_multiple_languages() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)
 
@@ -484,6 +484,6 @@ def test_existing_mnemonic_multiple_languages_argument() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
     # Clean up
     clean_key_folder(my_folder_path)

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -69,7 +69,7 @@ def test_new_mnemonic_bls_withdrawal(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -125,7 +125,7 @@ def test_new_mnemonic_withdrawal_address(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -186,7 +186,7 @@ def test_new_mnemonic_withdrawal_address_bad_checksum(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -243,7 +243,7 @@ def test_new_mnemonic_withdrawal_address_parameter(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -301,7 +301,7 @@ def test_new_mnemonic_eth1_withdrawal_address_param(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -359,7 +359,7 @@ def test_new_mnemonic_execution_address_param(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -530,7 +530,7 @@ async def test_script_bls_withdrawal() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -609,7 +609,7 @@ async def test_script_abbreviated_mnemonic() -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)
@@ -665,7 +665,7 @@ def test_new_mnemonic_custom_testnet(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in key_files:
-            assert get_permissions(validator_keys_folder_path, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(my_folder_path)

--- a/tests/test_cli/test_partial_deposit.py
+++ b/tests/test_cli/test_partial_deposit.py
@@ -68,7 +68,7 @@ def test_partial_deposit(amount: str) -> None:
     assert len(deposit_files) == 1
 
     if os.name == 'posix':
-        assert get_permissions(partial_deposit_folder, deposit_files[0]) == '0o440'
+        assert get_permissions(partial_deposit_folder, deposit_files[0]) == '0o400'
 
     clean_partial_deposit_folder(my_folder_path)
 
@@ -137,7 +137,7 @@ def test_partial_deposit_matches_existing_mnemonic_deposit() -> None:
     assert deposit_contents == partial_deposit_contents
 
     if os.name == 'posix':
-        assert get_permissions(partial_deposit_folder, partial_deposit_files[0]) == '0o440'
+        assert get_permissions(partial_deposit_folder, partial_deposit_files[0]) == '0o400'
 
     clean_folder(my_folder_path, validator_key_folder, True)
     clean_partial_deposit_folder(my_folder_path)
@@ -218,7 +218,7 @@ def test_partial_deposit_does_not_match_if_amount_differs() -> None:
     assert deposit_contents_dict["deposit_cli_version"] == partial_deposit_contents_dict["deposit_cli_version"]
 
     if os.name == 'posix':
-        assert get_permissions(partial_deposit_folder, partial_deposit_files[0]) == '0o440'
+        assert get_permissions(partial_deposit_folder, partial_deposit_files[0]) == '0o400'
 
     clean_folder(my_folder_path, validator_key_folder, True)
     clean_partial_deposit_folder(my_folder_path)
@@ -281,7 +281,7 @@ def test_partial_deposit_custom_network(amount: str) -> None:
     assert len(deposit_files) == 1
 
     if os.name == 'posix':
-        assert get_permissions(partial_deposit_folder, deposit_files[0]) == '0o440'
+        assert get_permissions(partial_deposit_folder, deposit_files[0]) == '0o400'
 
     clean_partial_deposit_folder(my_folder_path)
 

--- a/tests/test_cli/test_regeneration.py
+++ b/tests/test_cli/test_regeneration.py
@@ -56,7 +56,7 @@ def test_regeneration(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in part_1_key_files:
-            assert get_permissions(validator_keys_folder_path_1, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path_1, file_name) == '0o400'
 
     # Part 2: existing-mnemonic
     runner = CliRunner()
@@ -98,7 +98,7 @@ def test_regeneration(monkeypatch) -> None:
     # Verify file permissions
     if os.name == 'posix':
         for file_name in part_2_key_files:
-            assert get_permissions(validator_keys_folder_path_2, file_name) == '0o440'
+            assert get_permissions(validator_keys_folder_path_2, file_name) == '0o400'
 
     # Clean up
     clean_key_folder(folder_path_1)


### PR DESCRIPTION
**What I did**

I created a `sensitive_opener` to be used with the open built-in function to ensure that newly create sensitives files were using the 400 permissions with the O_EXCL flag set.

**Related issue**

Fixes #183 
