### PR TITLE
Use utf-8 encoding for all JSON file writing and reading

### DIFF
--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -67,6 +67,6 @@ def export_bls_to_execution_change_keystore_json(folder: str,
         'bls_to_execution_change_keystore_signature-%s-%i.json' % (index, timestamp)
     )
 
-    with open(filefolder, 'w', opener=sensitive_opener) as f:
+    with open(filefolder, 'w', encoding='utf-8', opener=sensitive_opener) as f:
         json.dump(signed_bls_to_execution_change_keystore_json, f)
     return filefolder

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -367,6 +367,6 @@ class CredentialList:
                     bar.update(1)
 
         filefolder = os.path.join(folder, 'bls_to_execution_change-%i.json' % time.time())
-        with open(filefolder, 'w', opener=sensitive_opener) as f:
+        with open(filefolder, 'w', encoding='utf-8', opener=sensitive_opener) as f:
             json.dump(bls_to_execution_changes, f)
         return filefolder

--- a/ethstaker_deposit/key_handling/keystore.py
+++ b/ethstaker_deposit/key_handling/keystore.py
@@ -99,7 +99,7 @@ class Keystore(BytesDataclass):
         """
         Save self as a JSON keystore.
         """
-        with open(filefolder, 'w', opener=sensitive_opener) as f:
+        with open(filefolder, 'w', encoding='utf-8', opener=sensitive_opener) as f:
             f.write(self.as_json())
 
     @classmethod

--- a/ethstaker_deposit/utils/deposit.py
+++ b/ethstaker_deposit/utils/deposit.py
@@ -8,6 +8,6 @@ from ethstaker_deposit.utils.file_handling import (
 
 def export_deposit_data_json(folder: str, timestamp: float, deposit_data: list[dict[str, bytes]]) -> str:
     file_folder = os.path.join(folder, 'deposit_data-%i.json' % timestamp)
-    with open(file_folder, 'w', opener=sensitive_opener) as f:
+    with open(file_folder, 'w', encoding='utf-8', opener=sensitive_opener) as f:
         json.dump(deposit_data, f, default=lambda x: x.hex())
     return file_folder

--- a/ethstaker_deposit/utils/exit_transaction.py
+++ b/ethstaker_deposit/utils/exit_transaction.py
@@ -58,6 +58,6 @@ def export_exit_transaction_json(folder: str, signed_exit: SignedVoluntaryExit, 
         )
     )
 
-    with open(filefolder, 'w', opener=sensitive_opener) as f:
+    with open(filefolder, 'w', encoding='utf-8', opener=sensitive_opener) as f:
         json.dump(signed_exit_json, f)
     return filefolder

--- a/tests/test_cli/test_partial_deposit.py
+++ b/tests/test_cli/test_partial_deposit.py
@@ -128,10 +128,10 @@ def test_partial_deposit_matches_existing_mnemonic_deposit() -> None:
 
     assert len(partial_deposit_files) == 1
 
-    with open(os.path.join(validator_key_folder, deposit_files[0]), 'r') as file1:
+    with open(os.path.join(validator_key_folder, deposit_files[0]), 'r', encoding='utf-8') as file1:
         deposit_contents = file1.read()
 
-    with open(os.path.join(partial_deposit_folder, partial_deposit_files[0]), 'r') as file2:
+    with open(os.path.join(partial_deposit_folder, partial_deposit_files[0]), 'r', encoding='utf-8') as file2:
         partial_deposit_contents = file2.read()
 
     assert deposit_contents == partial_deposit_contents
@@ -198,10 +198,10 @@ def test_partial_deposit_does_not_match_if_amount_differs() -> None:
 
     assert len(partial_deposit_files) == 1
 
-    with open(os.path.join(validator_key_folder, deposit_files[0]), 'r') as file1:
+    with open(os.path.join(validator_key_folder, deposit_files[0]), 'r', encoding='utf-8') as file1:
         deposit_contents = file1.read()
 
-    with open(os.path.join(partial_deposit_folder, partial_deposit_files[0]), 'r') as file2:
+    with open(os.path.join(partial_deposit_folder, partial_deposit_files[0]), 'r', encoding='utf-8') as file2:
         partial_deposit_contents = file2.read()
 
     assert deposit_contents != partial_deposit_contents


### PR DESCRIPTION
**What I did**

Modified all our open built-in function call to use utf-8 as the encoding since we are just writing and reading JSON files.

**Related issue**

Part of the fixes for #187 . Depends and builds on top of #208 .