### PR TITLE
Use a fake version value for the deposit data file to work around a Launchpad issue

### DIFF
--- a/docs/src/deposit_data_file.md
+++ b/docs/src/deposit_data_file.md
@@ -28,7 +28,7 @@ Each deposit from the list will contain this structure:
 - **deposit_data_root**: The deposit data root value to be passed to the deposit function call.
 - **fork_version**: The fork version of the network that this deposit file was created for.
 - **network_name**: The network name of the network that this deposit file was created for.
-- **deposit_cli_version**: The tool version used to create this file.
+- **deposit_cli_version**: The tool version used to create this file. We are currently faking this value to work around [an issue](https://github.com/eth-educators/ethstaker-deposit-cli/issues/216) with the Launchpad.
 
 ## Example
 ```JSON

--- a/ethstaker_deposit/cli/partial_deposit.py
+++ b/ethstaker_deposit/cli/partial_deposit.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.settings import (
-    DEPOSIT_CLI_VERSION,
+    fake_cli_version,
     MAINNET,
     ALL_CHAIN_KEYS,
     get_chain_setting,
@@ -177,7 +177,7 @@ def partial_deposit(
     deposit_data.update({'deposit_data_root': signed_deposit.hash_tree_root})
     deposit_data.update({'fork_version': chain_setting.GENESIS_FORK_VERSION})
     deposit_data.update({'network_name': chain_setting.NETWORK_NAME})
-    deposit_data.update({'deposit_cli_version': DEPOSIT_CLI_VERSION})
+    deposit_data.update({'deposit_cli_version': fake_cli_version})
     saved_folder = export_deposit_data_json(folder, time.time(), [deposit_data])
 
     click.echo(load_text(['msg_verify_partial_deposit']))

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -18,7 +18,11 @@ from ethstaker_deposit.key_handling.keystore import (
     Pbkdf2Keystore,
     ScryptKeystore,
 )
-from ethstaker_deposit.settings import DEPOSIT_CLI_VERSION, BaseChainSetting
+from ethstaker_deposit.settings import (
+    fake_cli_version,
+    DEPOSIT_CLI_VERSION,
+    BaseChainSetting,
+)
 from ethstaker_deposit.utils.constants import (
     BLS_WITHDRAWAL_PREFIX,
     EXECUTION_ADDRESS_WITHDRAWAL_PREFIX,
@@ -152,7 +156,7 @@ class Credential:
         datum_dict.update({'deposit_data_root': signed_deposit_datum.hash_tree_root})
         datum_dict.update({'fork_version': self.chain_setting.GENESIS_FORK_VERSION})
         datum_dict.update({'network_name': self.chain_setting.NETWORK_NAME})
-        datum_dict.update({'deposit_cli_version': DEPOSIT_CLI_VERSION})
+        datum_dict.update({'deposit_cli_version': fake_cli_version})
         return datum_dict
 
     def signing_keystore(self, password: str) -> Keystore:

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -5,6 +5,12 @@ from ethstaker_deposit import __version__
 
 DEPOSIT_CLI_VERSION = __version__
 
+# We are faking the deposit_cli_version to pass the current Launchpad version test
+# See https://github.com/eth-educators/ethstaker-deposit-cli/issues/216
+version_elements = DEPOSIT_CLI_VERSION.split('.')
+version_elements[0] = str(int(version_elements[0]) + 10)
+fake_cli_version = '.'.join(version_elements)
+
 
 class BaseChainSetting(NamedTuple):
     NETWORK_NAME: str


### PR DESCRIPTION
**What I did**

I'm modifying the version number we are using for the `deposit_cli_version` field in the deposit data files we are producing. I'm adding 10 to our major version number to make it large enough to pass the current Launchpad test in regards with this.

**Related issue**

Related to #216 . It doesn't entirely fix that issue, but it's a short term solution that works for now.
