### PR TITLE
Moved colorama dependency to platform dependent in requirements.txt

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements_test.txt
+          pip install -r requirements.txt -r requirements_test.txt
       - name: Run type checker
         run: python -m mypy --config-file mypy.ini -p ethstaker_deposit
       - name: Run linter
@@ -55,8 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements_test.txt
+          pip install -r requirements.txt -r requirements_test.txt
       - name: Run tests
         run: |
           coverage run --data-file=.coverage.${{ matrix.os }}.${{ matrix.python-version }} -m pytest tests
@@ -85,8 +83,7 @@ jobs:
         id: merge
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements_test.txt
+          pip install -r requirements.txt -r requirements_test.txt
           coverage combine coverage*
           coverage html
       - name: Upload final coverage html report

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,13 @@ clean:
 
 $(VENV_NAME)/bin/activate: requirements.txt
 	@test -d $(VENV_NAME) || python3 -m venv --clear $(VENV_NAME)
-	${VENV_NAME}/bin/python -m pip install -r requirements.txt
-	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
+	${VENV_NAME}/bin/python -m pip install -r requirements.txt -r requirements_test.txt
 	@touch $(VENV_NAME)/bin/activate
 
 venv_build: $(VENV_NAME)/bin/activate
 
 venv_build_test: venv_build
-	${VENV_NAME}/bin/python -m pip install -r requirements_test.txt
+	${VENV_NAME}/bin/python -m pip install -r requirements.txt -r requirements_test.txt
 
 venv_test: venv_build_test
 	$(VENV_ACTIVATE) && python -m pytest ./tests

--- a/build_configs/windows/requirements.in
+++ b/build_configs/windows/requirements.in
@@ -1,7 +1,6 @@
 # Windows binary build requirements
 # Only use this to get new hashes, don't upgrade requirements.txt directly with pip-compile:
 # It can't find pywin32
-colorama
 future
 pefile
 pywin32-ctypes

--- a/build_configs/windows/requirements.txt
+++ b/build_configs/windows/requirements.txt
@@ -1,9 +1,6 @@
 -r ../common/requirements.txt
 
 # Build tools for binary distribution
-colorama==0.4.6 \
-    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 future==1.0.0 \
     --hash=sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216 \
     --hash=sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05

--- a/docs/src/local_development.md
+++ b/docs/src/local_development.md
@@ -74,7 +74,6 @@ On Windows, you'll need:
 
 **To execute tests, you will need to install the test dependencies**:
 ```sh
-python3 -m pip install -r requirements.txt
-python3 -m pip install -r requirements_test.txt
+python3 -m pip install -r requirements.txt -r requirements_test.txt
 python3 -m pytest tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-    "colorama", # pip-compile did not pick up from mypy
     "exceptiongroup", # pip-compile did not pick up from mypy
     "flake8",
     "jsonschema",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,9 @@ cached-property==1.5.2 \
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
-colorama==0.4.6 \
+colorama==0.4.6; platform_system == 'Windows' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6 \
-    ; platform_system == 'Windows'
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 cytoolz==0.12.3 \
     --hash=sha256:01cfb8518828c1189200c02a5010ea404407fb18fd5589e29c126e84bbeadd36 \
     --hash=sha256:04afa90d9d9d18394c40d9bed48c51433d08b57c042e0e50c8c0f9799735dcbd \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ cached-property==1.5.2 \
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6 \
+    ; platform_system == 'Windows'
 cytoolz==0.12.3 \
     --hash=sha256:01cfb8518828c1189200c02a5010ea404407fb18fd5589e29c126e84bbeadd36 \
     --hash=sha256:04afa90d9d9d18394c40d9bed48c51433d08b57c042e0e50c8c0f9799735dcbd \

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,5 +1,4 @@
 # requirements_test.in
-colorama # pip-compile did not pick up from mypy
 exceptiongroup # pip-compile did not pick up from mypy
 flake8
 jsonschema

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,14 +4,9 @@
 #
 #    pip-compile --generate-hashes --no-annotate --output-file=requirements_test.txt requirements_test.in
 #
--r requirements.txt
-
 attrs==24.2.0 \
     --hash=sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346 \
     --hash=sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2
-colorama==0.4.6 \
-    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 exceptiongroup==1.2.2 \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc

--- a/uv.lock
+++ b/uv.lock
@@ -239,7 +239,6 @@ dependencies = [
 
 [package.optional-dependencies]
 test = [
-    { name = "colorama" },
     { name = "coverage" },
     { name = "exceptiongroup" },
     { name = "flake8" },
@@ -253,7 +252,6 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click" },
-    { name = "colorama", marker = "extra == 'test'" },
     { name = "coverage", marker = "extra == 'test'" },
     { name = "eth-typing" },
     { name = "eth-utils" },


### PR DESCRIPTION
**What I did**

The colorama package is only needed by click on Windows. It should be in `requirements.txt` as a platform dependent dependency just like it is [in click](https://github.com/pallets/click/blob/main/pyproject.toml#L18).

**Related issue**

This is related to the dependabot PRs and [the test failures](https://github.com/eth-educators/ethstaker-deposit-cli/actions/runs/11462141972/job/31892887693?pr=202) we are seeing on one of them. It should help with using dependabot to manage our dependencies.
