### PR TITLE
Adding the Mekong testnet settings as another supported testnet

### DIFF
--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -7,7 +7,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc...
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/exit_transaction_keystore.md
+++ b/docs/src/exit_transaction_keystore.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a keystore file.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to exit.
 

--- a/docs/src/exit_transaction_mnemonic.md
+++ b/docs/src/exit_transaction_mnemonic.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a mnemonic phrase.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--mnemonic`**: The mnemonic you used during key generation. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -9,7 +9,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_to_execution_changes_folder`**: The path to store the change JSON file.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -11,7 +11,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -9,7 +9,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--mnemonic_language`**: The language of the BIP-39 mnemonic. Options are: 'chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'portuguese', 'spanish'.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc...
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--num_validators`**: Number of validators to create.
 

--- a/docs/src/partial_deposit.md
+++ b/docs/src/partial_deposit.md
@@ -8,7 +8,7 @@ If you wish to create a validator with 0x00 credentials, you must use the **[new
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to deposit to.
 

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -29,6 +29,7 @@ class BaseChainSetting(NamedTuple):
 MAINNET = 'mainnet'
 SEPOLIA = 'sepolia'
 HOLESKY = 'holesky'
+MEKONG = 'mekong'
 EPHEMERY = 'ephemery'
 
 # Mainnet setting
@@ -49,6 +50,12 @@ HoleskySetting = BaseChainSetting(
     GENESIS_FORK_VERSION=bytes.fromhex('01017000'),
     EXIT_FORK_VERSION=bytes.fromhex('04017000'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1'))
+# Mekong setting
+MekongSetting = BaseChainSetting(
+    NETWORK_NAME=MEKONG,
+    GENESIS_FORK_VERSION=bytes.fromhex('10637624'),
+    EXIT_FORK_VERSION=bytes.fromhex('40637624'),
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9838240bca889c52818d7502179b393a828f61f15119d9027827c36caeb67db7'))
 # Ephemery setting
 # From https://github.com/ephemery-testnet/ephemery-genesis/blob/master/values.env
 EphemerySetting = BaseChainSetting(
@@ -65,6 +72,7 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     SEPOLIA: SepoliaSetting,
     HOLESKY: HoleskySetting,
+    MEKONG: MekongSetting,
     EPHEMERY: EphemerySetting,
 }
 


### PR DESCRIPTION
**What I did**

Added the Mekong testnet settings so it can be used as any other supported testnet with his name without having to manually use the `--devnet_chain_setting` flag.

You can find and confirm these settings on https://mekong.ethpandaops.io/.

- Genesis fork version: https://github.com/ethpandaops/mekong-devnets/blob/master/network-configs/devnet-0/metadata/config.yaml
- Exit fork version: https://github.com/ethpandaops/mekong-devnets/blob/master/network-configs/devnet-0/metadata/config.yaml
- Genesis validators root: https://github.com/ethpandaops/mekong-devnets/blob/master/network-configs/devnet-0/metadata/genesis_validators_root.txt