### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/src/bls_to_execution_change_file.md
+++ b/docs/src/bls_to_execution_change_file.md
@@ -2,7 +2,7 @@
 
 A BLS to execution change file is created when calling the **[generate-bls-to-execution-change](generate_bls_to_execution_change.md)** command.
 
-The BLS to execution change file is a JSON file. It contains a list of messages to change the withdrawal credentials for one or many validators. The format of the BLS to execution change file is loosly based on the input for the POST `/eth/v1/beacon/pool/bls_to_execution_changes` [API endpoint](https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolBLSToExecutionChange) as defined by [the Ethereum Beacon APIs](https://github.com/ethereum/beacon-APIs). Part of this content is based on the [SignedBLSToExecutionChange](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#signedblstoexecutionchange) container as defined in the [Ethereum Consensus Specifications](https://github.com/ethereum/consensus-specs/).
+The BLS to execution change file is a JSON file. It contains a list of messages to change the withdrawal credentials for one or many validators. The format of the BLS to execution change file is loosely based on the input for the POST `/eth/v1/beacon/pool/bls_to_execution_changes` [API endpoint](https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolBLSToExecutionChange) as defined by [the Ethereum Beacon APIs](https://github.com/ethereum/beacon-APIs). Part of this content is based on the [SignedBLSToExecutionChange](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#signedblstoexecutionchange) container as defined in the [Ethereum Consensus Specifications](https://github.com/ethereum/consensus-specs/).
 
 ## Broadcasting
 

--- a/docs/src/quick_setup.md
+++ b/docs/src/quick_setup.md
@@ -42,11 +42,11 @@ This step requires you to be online. If you want to perform this offline, follow
 
 **Windows users:** You should replace `./deposit` with `deposit.exe` to run properly.
 
-**MacOS users:** In order to run from the terminal, you must first open the file to bypass MacOS code signing issues. Do so by right clicking the `deposit` file and then selecting `Open`.
+**MacOS users:** In order to run from the terminal, you must first open the file to bypass MacOS code signing issues. Do so by right-clicking the `deposit` file and then selecting `Open`.
 
 **Linux users:** On Unix-based systems, keystores and the deposit_data*.json have 440/-r--r----- file permissions (user & group read only). This improves security by limiting which users and processes that have access to these files. If you are getting permission denied errors when handling your keystores, consider changing which user/group owns the file (with chown) or, if need be, change the file permissions with chmod.
 
-Determine which command best suites what you would like to accomplish:
+Determine which command best suits what you would like to accomplish:
 
 - **[new-mnemonic](new_mnemonic.md)**: Used to generate a new mnemonic, validator keys, and deposit file. It is not recommended to use this command if you have existing validators.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "loosly" to "loosely".
Corrected "right clicking" to "right-clicking".
Corrected "suites" to "suits".

Please review the changes and let me know if any additional changes are needed.
