### PR TITLE
Call everything in clear terminal twice

### DIFF
--- a/ethstaker_deposit/cli/exit_transaction_mnemonic.py
+++ b/ethstaker_deposit/cli/exit_transaction_mnemonic.py
@@ -31,6 +31,7 @@ from ethstaker_deposit.utils.validation import (
     verify_signed_exit_json,
     validate_devnet_chain_setting,
 )
+from ethstaker_deposit.utils.terminal import clear_terminal
 
 
 def _credential_builder(kwargs: Dict[str, Any]) -> Credential:
@@ -122,6 +123,9 @@ def exit_transaction_mnemonic(
         **kwargs: Any) -> None:
 
     folder = os.path.join(output_folder, DEFAULT_EXIT_TRANSACTION_FOLDER_NAME)
+    if not os.path.exists(folder):
+        os.mkdir(folder)
+    clear_terminal()
 
     # Get chain setting
     chain_setting = devnet_chain_setting if devnet_chain_setting is not None else get_chain_setting(chain)
@@ -148,9 +152,6 @@ def exit_transaction_mnemonic(
             for credential in executor.map(_credential_builder, executor_kwargs):
                 credentials.append(credential)
                 bar.update(1)
-
-    if not os.path.exists(folder):
-        os.mkdir(folder)
 
     transaction_filefolders = []
     with click.progressbar(length=num_keys,  # type: ignore[var-annotated]

--- a/ethstaker_deposit/utils/terminal.py
+++ b/ethstaker_deposit/utils/terminal.py
@@ -18,22 +18,24 @@ def clear_terminal() -> None:
     elif sys.platform == 'darwin':
         clean_env = os.environ.copy()
 
-    if sys.platform == 'win32':
-        # Special-case for asyncio pytest on Windows
-        if os.getenv("IS_ASYNC_TEST") == "1":
-            click.clear()
-        elif shutil.which('clear'):
-            subprocess.run(['clear'])
+    for count in range(2):
+        # Call everything twice to complete the clear on iTerm2 and for good measure
+        if sys.platform == 'win32':
+            # Special-case for asyncio pytest on Windows
+            if os.getenv("IS_ASYNC_TEST") == "1":
+                click.clear()
+            elif shutil.which('clear'):
+                subprocess.run(['clear'])
+            else:
+                subprocess.run('cls', shell=True)
+        elif sys.platform == 'linux' or sys.platform == 'darwin':
+            if shutil.which('clear'):
+                subprocess.run(['clear'], env=clean_env)
+            else:
+                click.clear()
+            if shutil.which('tput'):
+                subprocess.run(['tput', 'reset'], env=clean_env)
+            if shutil.which('reset'):
+                subprocess.run(['reset'], env=clean_env)
         else:
-            subprocess.run('cls', shell=True)
-    elif sys.platform == 'linux' or sys.platform == 'darwin':
-        if shutil.which('clear'):
-            subprocess.run(['clear'], env=clean_env)
-        else:
             click.clear()
-        if shutil.which('tput'):
-            subprocess.run(['tput', 'reset'], env=clean_env)
-        if shutil.which('reset'):
-            subprocess.run(['reset'], env=clean_env)
-    else:
-        click.clear()

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "ethstaker-deposit"
-version = "0.3.1.dev0"
+version = "0.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The scrollback history on iTerm2 is only cleared when calling clear twice. This should fixed the issue.

**Related issue**

Fixes #186
