### PR TITLE
feat: add Gnosis and Chiado

### DIFF
--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -7,7 +7,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/exit_transaction_keystore.md
+++ b/docs/src/exit_transaction_keystore.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a keystore file.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to exit.
 

--- a/docs/src/exit_transaction_mnemonic.md
+++ b/docs/src/exit_transaction_mnemonic.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a mnemonic phrase.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used during key generation. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -9,7 +9,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_to_execution_changes_folder`**: The path to store the change JSON file.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -11,7 +11,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -9,7 +9,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--mnemonic_language`**: The language of the BIP-39 mnemonic. Options are: 'chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'portuguese', 'spanish'.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--num_validators`**: Number of validators to create.
 

--- a/docs/src/partial_deposit.md
+++ b/docs/src/partial_deposit.md
@@ -8,7 +8,7 @@ If you wish to create a validator with 0x00 credentials, you must use the **[new
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', or 'ephemery'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to deposit to.
 

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -31,6 +31,8 @@ SEPOLIA = 'sepolia'
 HOLESKY = 'holesky'
 MEKONG = 'mekong'
 EPHEMERY = 'ephemery'
+GNOSIS = 'gnosis'
+CHIADO = 'chiado'
 
 # Mainnet setting
 MainnetSetting = BaseChainSetting(
@@ -66,6 +68,18 @@ EphemerySetting = BaseChainSetting(
     # You can manually obtain the GENESIS_VALIDATORS_ROOT with each reset on
     # https://github.com/ephemery-testnet/ephemery-genesis/releases
     GENESIS_VALIDATORS_ROOT=None)
+# Gnosis setting
+GnosisSetting = BaseChainSetting(
+    NETWORK_NAME=GNOSIS,
+    GENESIS_FORK_VERSION=bytes.fromhex('00000064'),
+    EXIT_FORK_VERSION=bytes.fromhex('03000064'),
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47'))
+# Chiado setting
+ChiadoSetting = BaseChainSetting(
+    NETWORK_NAME=CHIADO,
+    GENESIS_FORK_VERSION=bytes.fromhex('0000006f'),
+    EXIT_FORK_VERSION=bytes.fromhex('0300006f'),
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9d642dac73058fbf39c0ae41ab1e34e4d889043cb199851ded7095bc99eb4c1e'))
 
 
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
@@ -74,6 +88,8 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     HOLESKY: HoleskySetting,
     MEKONG: MekongSetting,
     EPHEMERY: EphemerySetting,
+    GNOSIS: GnosisSetting,
+    CHIADO: ChiadoSetting,
 }
 
 ALL_CHAIN_KEYS: tuple[str, ...] = tuple(ALL_CHAINS.keys())


### PR DESCRIPTION
**What I did**

I added Gnosis Chain and Chiado (the Gnosis Chain testnet) to the compatible networks.

**Future changes**

If we can do it in an elegant way, we'd also love to create a separate PR to update the `--amount` argument, as Gnosis Chain has the minimum set to 1 GNO and the maximum to 64 GNO, so the same as Ethereum but divided by 32. This would be ideal in order not to confuse our users.