### PR TITLE
Switch to public Linux arm runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm64, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**What I did**

Switched us to public Linux ARM runners

See https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/user-attachments/assets/683d8800-f5df-4c12-a1ab-caa66a877420)
