### PR TITLE
Deb/feat/make defaults contextful

### DIFF
--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -135,11 +135,9 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
             callback=captive_prompt_callback(
                 lambda amount, **kwargs: validate_deposit_amount(amount, **kwargs),
                 lambda: load_text(['arg_amount', 'prompt'], func='generate_keys_arguments_decorator'),
-                default=str(min_activation_amount_eth),
                 prompt_if=prompt_if_other_value('compounding', True),
                 prompt_marker="amount",
             ),
-            default=str(min_activation_amount_eth),
             help=lambda: load_text(['arg_amount', 'help'], func='generate_keys_arguments_decorator'),
             param_decls='--amount',
             prompt=False,  # the callback handles the prompt

--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -133,10 +133,11 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
         ),
         jit_option(
             callback=captive_prompt_callback(
-                lambda amount: validate_deposit_amount(amount),
+                lambda amount, **kwargs: validate_deposit_amount(amount, **kwargs),
                 lambda: load_text(['arg_amount', 'prompt'], func='generate_keys_arguments_decorator'),
                 default=str(min_activation_amount_eth),
                 prompt_if=prompt_if_other_value('compounding', True),
+                prompt_marker="amount",
             ),
             default=str(min_activation_amount_eth),
             help=lambda: load_text(['arg_amount', 'help'], func='generate_keys_arguments_decorator'),
@@ -178,6 +179,8 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
 
     # Get chain setting
     chain_setting = devnet_chain_setting if devnet_chain_setting is not None else get_chain_setting(chain)
+
+    amounts = [amount * chain_setting.MULPLIER for amount in amounts]
 
     if not os.path.exists(folder):
         os.mkdir(folder)

--- a/ethstaker_deposit/cli/partial_deposit.py
+++ b/ethstaker_deposit/cli/partial_deposit.py
@@ -98,7 +98,7 @@ FUNC_NAME = 'partial_deposit'
 )
 @jit_option(
     callback=captive_prompt_callback(
-        lambda amount: validate_deposit_amount(amount),
+        lambda amount, **kwargs: validate_deposit_amount(amount, **kwargs),
         lambda: load_text(['arg_partial_deposit_amount', 'prompt'], func=FUNC_NAME),
         default="32",
         prompt_if=prompt_if_none,

--- a/ethstaker_deposit/intl/en/cli/generate_keys.json
+++ b/ethstaker_deposit/intl/en/cli/generate_keys.json
@@ -29,7 +29,7 @@
         },
         "arg_amount": {
             "help": "The amount to deposit to these validators in ether denomination. Must be at least 1 ether and can not have greater precision than 1 gwei. Use of this option requires compounding validators.",
-            "prompt": "Please enter the amount you wish to deposit to these validators. Must be at least 1 ether and can not have greater precision than 1 gwei. 32 is required to activate a new validator"
+            "prompt": "Please enter the amount you wish to deposit to these validators. Must be at least {min_deposit} and can not have greater precision than 1 gwei. {activation_amount} is required to activate a new validator"
         },
         "arg_pbkdf2": {
             "help": "Uses the pbkdf2 hashing function instead of scrypt for generated keystore files. "

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -17,13 +17,17 @@ class BaseChainSetting(NamedTuple):
     GENESIS_FORK_VERSION: bytes
     EXIT_FORK_VERSION: bytes  # capella fork version for voluntary exits (EIP-7044)
     GENESIS_VALIDATORS_ROOT: Optional[bytes] = None
+    MULPLIER: int = 1
+    MINIMUM_COMPOUNDING_DEPOSIT: int = 1
 
     def __str__(self) -> str:
         gvr_value = self.GENESIS_VALIDATORS_ROOT.hex() if self.GENESIS_VALIDATORS_ROOT is not None else 'None'
         return (f'Network {self.NETWORK_NAME}\n'
                 f'  - Genesis fork version: {self.GENESIS_FORK_VERSION.hex()}\n'
                 f'  - Exit fork version: {self.EXIT_FORK_VERSION.hex()}\n'
-                f'  - Genesis validators root: {gvr_value}')
+                f'  - Genesis validators root: {gvr_value}\n'
+                f'  - Multiplier: {self.MULPLIER}\n'
+                f'  - Minimum compounding deposit: {self.MINIMUM_COMPOUNDING_DEPOSIT}')
 
 
 MAINNET = 'mainnet'
@@ -73,13 +77,17 @@ GnosisSetting = BaseChainSetting(
     NETWORK_NAME=GNOSIS,
     GENESIS_FORK_VERSION=bytes.fromhex('00000064'),
     EXIT_FORK_VERSION=bytes.fromhex('03000064'),
-    GENESIS_VALIDATORS_ROOT=bytes.fromhex('f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47'))
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47'),
+    MULPLIER=32,
+    MINIMUM_COMPOUNDING_DEPOSIT=0.03125)
 # Chiado setting
 ChiadoSetting = BaseChainSetting(
     NETWORK_NAME=CHIADO,
     GENESIS_FORK_VERSION=bytes.fromhex('0000006f'),
     EXIT_FORK_VERSION=bytes.fromhex('0300006f'),
-    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9d642dac73058fbf39c0ae41ab1e34e4d889043cb199851ded7095bc99eb4c1e'))
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9d642dac73058fbf39c0ae41ab1e34e4d889043cb199851ded7095bc99eb4c1e'),
+    MULPLIER=32,
+    MINIMUM_COMPOUNDING_DEPOSIT=0.03125)
 
 
 ALL_CHAINS: Dict[str, BaseChainSetting] = {

--- a/ethstaker_deposit/utils/click.py
+++ b/ethstaker_deposit/utils/click.py
@@ -166,10 +166,11 @@ def captive_prompt_callback(
         # To avoid showing confirmation prompt twice, we introduce a flag to prompt inside
         # the callback
         # See https://github.com/pallets/click/discussions/2673
+        default_value = _value_of(default) if default is not None else param.default
         if (prompt_if is not None
                 and ctx.get_parameter_source(param.name) == click.core.ParameterSource.DEFAULT
                 and prompt_if(ctx, param, user_input)):
-            user_input = click.prompt(prompt(), hide_input=hide_input, default=_value_of(default))
+            user_input = click.prompt(prompt(), hide_input=hide_input, default=default_value)
         if config.non_interactive:
             return process_with_optional_context(ctx, processing_func, user_input)
         while True:

--- a/ethstaker_deposit/utils/constants.py
+++ b/ethstaker_deposit/utils/constants.py
@@ -43,7 +43,7 @@ CONTEXT_REQUIRING_PROMPTS = [
 ]
 
 
-def get_min_activation_amount(chain: str, **kwargs) -> int:
+def get_min_activation_amount(chain: str) -> int:
     """
     Returns the minimum activation amount for the specified chain.
     Defaults to 32 ETH unless overridden for a specific chain.

--- a/ethstaker_deposit/utils/constants.py
+++ b/ethstaker_deposit/utils/constants.py
@@ -32,6 +32,25 @@ DEFAULT_PARTIAL_DEPOSIT_FOLDER_NAME = 'partial_deposits'
 INTL_CONTENT_PATH = os.path.join('ethstaker_deposit', 'intl')
 
 
+CHAIN_MIN_ACTIVATION_OVERRIDES: Dict[str, int] = {
+    'chiado': 1 * ETH2GWEI,
+    'gnosis': 1 * ETH2GWEI,
+}
+
+
+CONTEXT_REQUIRING_PROMPTS = [
+    "amount",
+]
+
+
+def get_min_activation_amount(chain: str, **kwargs) -> int:
+    """
+    Returns the minimum activation amount for the specified chain.
+    Defaults to 32 ETH unless overridden for a specific chain.
+    """
+    return CHAIN_MIN_ACTIVATION_OVERRIDES.get(chain, MIN_ACTIVATION_AMOUNT) // ETH2GWEI
+
+
 def _add_index_to_options(d: Dict[str, list[str]]) -> Dict[str, list[str]]:
     '''
     Adds the (1 indexed) index (in the dict) to the first element of value list.


### PR DESCRIPTION
**What I did**
Make "amount" contextful. Chains like Gnosis have different default values and different scaling constants for amounts. Added a field called `prompt_marker` to the callback so that it is aware of what command it is for. Modified the `get_default ` function so it fetches the default from chain settings. Added `ctx.params` as an input to the `validate_deposit_amount` function as a keyword argument a scaling factor. The default amounts and scaling parameters are defined in the chain settings. These default values also added to helper text through a new `get_amount_prompt_from_template` function.

These changes allow the deposit cli to process chain-specific deviations from the standard defaults in a generalized way.

**Related issue**
Makes command defaults/values contextful. Not related to an existing issue.
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![mandatory pup gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXFtdzRmbDYwbnoyeWhjODFmdXlxOHI0bnl4Mmg5YWdlM2tlOXRxdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cJfY82h8ijUFQEmDKa/giphy.gif)
