### PR TITLE
Bump Dockerfile to Python 3.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# This image is from python:3.12.7-slim-bookworm (https://hub.docker.com/_/python)
-FROM python@sha256:032c52613401895aa3d418a4c563d2d05f993bc3ecc065c8f4e2280978acd249
+# This image is from python:3.13.2-slim-bookworm (https://hub.docker.com/_/python)
+FROM python@sha256:ae9f9ac89467077ed1efefb6d9042132d28134ba201b2820227d46c9effd3174
 
 WORKDIR /app
 


### PR DESCRIPTION
**What I did**
Dockerfile uses the sha256 for Python 3.13.2 slim-bookworm

Small dependency maintenance