### PR TITLE
Update Ubuntu runner image to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**What I did**

I updated Ubuntu runner image from 20.04 to 22.04. The 20.04 image will become unsupported on April 1 with a brownout period starting on March 4.

This is related to this announcement: https://github.com/actions/runner-images/issues/11101
