### PR TITLE
Removing Mekong and adding Hoodi testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ Depositing to the wrong address **will** lose you your ETH.
 - Ethereum Holešky (Holešovice) testnet
   - Deposit address: [0x4242424242424242424242424242424242424242](https://holesky.etherscan.io/address/0x4242424242424242424242424242424242424242)
   - [Launchpad](https://holesky.launchpad.ethereum.org/)
+- Ethereum Hoodi testnet
+  - Deposit address: [0x00000000219ab540356cBB839Cbe05303d7705Fa](https://hoodi.etherscan.io/address/0x00000000219ab540356cBB839Cbe05303d7705Fa)
+  - [Launchpad](https://hoodi.launchpad.ethereum.org/)

--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -7,7 +7,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -7,7 +7,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/exit_transaction_keystore.md
+++ b/docs/src/exit_transaction_keystore.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a keystore file.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to exit.
 

--- a/docs/src/exit_transaction_keystore.md
+++ b/docs/src/exit_transaction_keystore.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a keystore file.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to exit.
 

--- a/docs/src/exit_transaction_mnemonic.md
+++ b/docs/src/exit_transaction_mnemonic.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a mnemonic phrase.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used during key generation. <span class="warning"></span>
 

--- a/docs/src/exit_transaction_mnemonic.md
+++ b/docs/src/exit_transaction_mnemonic.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a mnemonic phrase.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used during key generation. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -9,7 +9,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_to_execution_changes_folder`**: The path to store the change JSON file.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -9,7 +9,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_to_execution_changes_folder`**: The path to store the change JSON file.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -11,7 +11,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -11,7 +11,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -9,7 +9,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--mnemonic_language`**: The language of the BIP-39 mnemonic. Options are: 'chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'portuguese', 'spanish'.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--num_validators`**: Number of validators to create.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -9,7 +9,7 @@ Generates a new BIP-39 mnemonic along with validator keystore and deposit files 
 
 - **`--mnemonic_language`**: The language of the BIP-39 mnemonic. Options are: 'chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'portuguese', 'spanish'.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--num_validators`**: Number of validators to create.
 

--- a/docs/src/partial_deposit.md
+++ b/docs/src/partial_deposit.md
@@ -8,7 +8,7 @@ If you wish to create a validator with 0x00 credentials, you must use the **[new
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'mekong', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to deposit to.
 

--- a/docs/src/partial_deposit.md
+++ b/docs/src/partial_deposit.md
@@ -8,7 +8,7 @@ If you wish to create a validator with 0x00 credentials, you must use the **[new
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to deposit to.
 

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -29,6 +29,7 @@ class BaseChainSetting(NamedTuple):
 MAINNET = 'mainnet'
 SEPOLIA = 'sepolia'
 HOLESKY = 'holesky'
+HOODI = 'hoodi'
 EPHEMERY = 'ephemery'
 GNOSIS = 'gnosis'
 CHIADO = 'chiado'
@@ -51,7 +52,12 @@ HoleskySetting = BaseChainSetting(
     GENESIS_FORK_VERSION=bytes.fromhex('01017000'),
     EXIT_FORK_VERSION=bytes.fromhex('04017000'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1'))
-
+# Hoodi setting
+HoodiSetting = BaseChainSetting(
+    NETWORK_NAME=HOODI,
+    GENESIS_FORK_VERSION=bytes.fromhex('10000910'),
+    EXIT_FORK_VERSION=bytes.fromhex('40000910'),
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f'))
 # Ephemery setting
 # From https://github.com/ephemery-testnet/ephemery-genesis/blob/master/values.env
 EphemerySetting = BaseChainSetting(
@@ -80,6 +86,7 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     SEPOLIA: SepoliaSetting,
     HOLESKY: HoleskySetting,
+    HOODI: HoodiSetting,
     EPHEMERY: EphemerySetting,
     GNOSIS: GnosisSetting,
     CHIADO: ChiadoSetting,

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -29,7 +29,6 @@ class BaseChainSetting(NamedTuple):
 MAINNET = 'mainnet'
 SEPOLIA = 'sepolia'
 HOLESKY = 'holesky'
-MEKONG = 'mekong'
 EPHEMERY = 'ephemery'
 GNOSIS = 'gnosis'
 CHIADO = 'chiado'
@@ -52,12 +51,7 @@ HoleskySetting = BaseChainSetting(
     GENESIS_FORK_VERSION=bytes.fromhex('01017000'),
     EXIT_FORK_VERSION=bytes.fromhex('04017000'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1'))
-# Mekong setting
-MekongSetting = BaseChainSetting(
-    NETWORK_NAME=MEKONG,
-    GENESIS_FORK_VERSION=bytes.fromhex('10637624'),
-    EXIT_FORK_VERSION=bytes.fromhex('40637624'),
-    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9838240bca889c52818d7502179b393a828f61f15119d9027827c36caeb67db7'))
+
 # Ephemery setting
 # From https://github.com/ephemery-testnet/ephemery-genesis/blob/master/values.env
 EphemerySetting = BaseChainSetting(
@@ -86,7 +80,6 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     SEPOLIA: SepoliaSetting,
     HOLESKY: HoleskySetting,
-    MEKONG: MekongSetting,
     EPHEMERY: EphemerySetting,
     GNOSIS: GnosisSetting,
     CHIADO: ChiadoSetting,


### PR DESCRIPTION
**What I did**

This is in relation with the recent deprecation of Mekong and the new Hoodi testnet to replace Holesky.

See:
- https://github.com/eth-clients/hoodi
