### PR TITLE
feat: Add Kurtosis testnet support

### DIFF
--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -39,6 +39,7 @@ HOODI = 'hoodi'
 EPHEMERY = 'ephemery'
 GNOSIS = 'gnosis'
 CHIADO = 'chiado'
+KURTOSIS = 'kurtosis'
 
 # Mainnet setting
 MainnetSetting = BaseChainSetting(
@@ -92,6 +93,16 @@ ChiadoSetting = BaseChainSetting(
     MULTIPLIER=32,
     MIN_ACTIVATION_AMOUNT=1,
     MIN_DEPOSIT_AMOUNT=0.03125)
+# Kurtosis setting
+KurtosisSetting = BaseChainSetting(
+    NETWORK_NAME=KURTOSIS,
+    GENESIS_FORK_VERSION=bytes.fromhex('10000038'),
+    EXIT_FORK_VERSION=bytes.fromhex('40000910'),  # Same as Hoodi
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('088243f664aec6b906743c9142cb2b8a1dc55e0b8f0d2aed841c2371eee0cccd'),
+    MULTIPLIER=1,  # Same as Hoodi (default)
+    MIN_ACTIVATION_AMOUNT=32.0,  # Same as Hoodi (default)
+    MIN_DEPOSIT_AMOUNT=1.0,  # Same as Hoodi (default)
+)
 
 
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
@@ -102,6 +113,7 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     EPHEMERY: EphemerySetting,
     GNOSIS: GnosisSetting,
     CHIADO: ChiadoSetting,
+    KURTOSIS: KurtosisSetting,
 }
 
 ALL_CHAIN_KEYS: tuple[str, ...] = tuple(ALL_CHAINS.keys())

--- a/requirements.txt
+++ b/requirements.txt
@@ -388,3 +388,5 @@ toolz==1.0.0 \
 typing-inspection==0.4.0 \
     --hash=sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f \
     --hash=sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122
+typing_extensions==4.13.2 \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c


### PR DESCRIPTION
This pull request introduces support for a new blockchain network, "Kurtosis," in the `ethstaker_deposit` settings. The changes involve defining the network, adding its configuration, and integrating it into the existing chain settings.

### Addition of Kurtosis network:

* [`ethstaker_deposit/settings.py`](diffhunk://#diff-929c3bc3ee35ade581646c4653a285711bdb0b60e8a84190331a43bebdec3a0dR42): Added `KURTOSIS` to the list of supported networks.
* [`ethstaker_deposit/settings.py`](diffhunk://#diff-929c3bc3ee35ade581646c4653a285711bdb0b60e8a84190331a43bebdec3a0dR96-R105): Defined `KurtosisSetting` with specific parameters such as `GENESIS_FORK_VERSION`, `EXIT_FORK_VERSION`, and deposit-related values.
* [`ethstaker_deposit/settings.py`](diffhunk://#diff-929c3bc3ee35ade581646c4653a285711bdb0b60e8a84190331a43bebdec3a0dR116): Integrated `KurtosisSetting` into the `ALL_CHAINS` dictionary, making it available alongside other network configurations.**What I did**

**Related issue**
None
