### PR TITLE
Fix packaging for use as a library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["ethstaker_deposit"]
+[tool.setuptools.packages.find]
+where = ["."]
 
 [tool.setuptools.dynamic]
 version = {attr = "ethstaker_deposit.__version__"}


### PR DESCRIPTION
**What I did**

Dynamically find packages so we don't just have `ethstaker_deposit` top level, but also everything below it that has an `__init__.py`. This allows users to use it in `requirements.txt` thusly:

```
ethstaker-deposit @ git+https://github.com/eth-educators/ethstaker-deposit-cli@v1.3.0
```

(Assuming 1.3.0 has this fix in it)

**Related issue**

Closes #286 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/user-attachments/assets/63a8c59b-a0ef-48ea-824d-8b81dcebfad0)
