### PR TITLE
Dependabot groups pydantic and pydantic-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      pydantic-deps:
+        patterns:
+          - "pydantic*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
**What I did**

Grouped `pydantic` and `pydantic-core`

This should help with keeping the two in lockstep, combined with maybe a dependabot command to ignore a `pydantic-core` update that is ahead of `pydantic`

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/user-attachments/assets/828104e7-eded-4087-8701-96797b303138)
