### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,8 @@
 name: ci-runner
 run-name: ${{ github.actor }} is testing and measuring code quality
+permissions:
+  contents: read
+  actions: read
 on:
   push:
     branches: [main]
@@ -38,6 +41,9 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-tests') ||
       github.event_name == 'push'
+    permissions:
+      contents: read
+      actions: write
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -88,6 +94,9 @@ jobs:
   coverage-combine:
     needs: ci-runner
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/5](https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks where necessary to grant additional permissions for specific tasks. Based on the workflow's actions, the following permissions are required:
- `contents: read` for basic repository access.
- `actions: read` for downloading and uploading artifacts.
- `id-token: write` if OpenID Connect tokens are used (not evident in this workflow but can be added if needed).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
