### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   completed-coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'


### PR DESCRIPTION
Potential fix for [https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/3](https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `completed-coverage` job, specifying only the permissions required for the job to function. Based on the job's actions, it only needs `contents: read` to access repository data. This change ensures the job adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
