### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: docs
 run-name: ${{ github.actor }} is running docs
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/2](https://github.com/eth-educators/ethstaker-deposit-cli/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the permissions required. Since the workflow involves building and deploying documentation, it will need `contents: read` for reading repository content and `contents: write` for deploying the built documentation. These permissions will be scoped to the minimal required level.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
