### PR TITLE
Add missing typing_extensions pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -400,3 +400,6 @@ toolz==1.0.0 \
 typing-inspection==0.4.1 \
     --hash=sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51 \
     --hash=sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28
+typing-extensions==4.13.2 \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
+    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef


### PR DESCRIPTION
**What I did**

I added a missing package pin for building.

**Related issue**

This became apparent with these recent build logs: https://github.com/eth-educators/ethstaker-deposit-cli/actions/runs/15347412544/job/43186752998
