### PR TITLE
Change repo to ethstaker

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -20,12 +20,12 @@
 
 # Building process
 
-Release assets were built using Github Actions and [this workflow run](`[WORKFLOW-RUN-URL]`). You can establish the provenance of this build using [our artifact attestations](https://github.com/eth-educators/ethstaker-deposit-cli/attestations).
+Release assets were built using Github Actions and [this workflow run](`[WORKFLOW-RUN-URL]`). You can establish the provenance of this build using [our artifact attestations](https://github.com/ethstaker/ethstaker-deposit-cli/attestations).
 
 With [the GitHub CLI](https://cli.github.com/) installed, a simple way to verify these assets is to run this command while replacing `[filename]` with the path to the downloaded asset:
 
 ```console
-gh attestation verify [filename] --repo eth-educators/ethstaker-deposit-cli
+gh attestation verify [filename] --repo ethstaker/ethstaker-deposit-cli
 ```
 
 This step requires you to be online. If you want to perform this offline, follow [these instructions from GitHub](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VENV_NAME?=venv
 VENV_ACTIVATE=. $(VENV_NAME)/bin/activate
 PYTHON=${VENV_NAME}/bin/python3.12
-DOCKER_IMAGE="eth-educators/ethstaker-deposit-cli:latest"
+DOCKER_IMAGE="ghcr.io/ethstaker/ethstaker-deposit-cli:latest"
 
 help:
 	@echo "clean - remove build and Python file artifacts"

--- a/deposit.sh
+++ b/deposit.sh
@@ -21,7 +21,7 @@ elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     python -m ethstaker_deposit "$@"
 
 else
-    echo "Sorry, to run deposit-cli on" $(uname -s)", please see the trouble-shooting on https://github.com/eth-educators/ethstaker-deposit-cli"
+    echo "Sorry, to run deposit-cli on" $(uname -s)", please see the trouble-shooting on https://github.com/ethstaker/ethstaker-deposit-cli"
     exit 1
 
 fi

--- a/docs/src/bls_to_execution_change_keystore_file.md
+++ b/docs/src/bls_to_execution_change_keystore_file.md
@@ -6,7 +6,7 @@ The BLS to execution change keystore file is a JSON file. The format is very sim
 
 ## Utilizing
 
-There is currently no integration with this file format with either the execution layer or beacon chain. The `signature` value must be provided as the `keystore_signature` for the [Signature file](https://github.com/eth-educators/update-credentials-without-mnemonic#signature-file-format).
+There is currently no integration with this file format with either the execution layer or beacon chain. The `signature` value must be provided as the `keystore_signature` for the [Signature file](https://github.com/ethstaker/update-credentials-without-mnemonic#signature-file-format).
 
 ## Example
 ```JSON

--- a/docs/src/deposit_data_file.md
+++ b/docs/src/deposit_data_file.md
@@ -28,7 +28,7 @@ Each deposit from the list will contain this structure:
 - **deposit_data_root**: The deposit data root value to be passed to the deposit function call.
 - **fork_version**: The fork version of the network that this deposit file was created for.
 - **network_name**: The network name of the network that this deposit file was created for.
-- **deposit_cli_version**: The tool version used to create this file. We are currently faking this value to work around [an issue](https://github.com/eth-educators/ethstaker-deposit-cli/issues/216) with the Launchpad.
+- **deposit_cli_version**: The tool version used to create this file. We are currently faking this value to work around [an issue](https://github.com/ethstaker/ethstaker-deposit-cli/issues/216) with the Launchpad.
 
 ## Example
 ```JSON

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -3,7 +3,7 @@
 <div class="warning">
 This command is associated with the a proposed solution to update withdrawal credentials for those who are missing their mnemonic. At this point this has not been approved or implemented and there is no guarantee credentials will be modified in the future.
 
-The project is located [here](https://github.com/eth-educators/update-credentials-without-mnemonic) if you would like to learn more.
+The project is located [here](https://github.com/ethstaker/update-credentials-without-mnemonic) if you would like to learn more.
 </div>
 
 ## Description

--- a/docs/src/landing.md
+++ b/docs/src/landing.md
@@ -1,6 +1,6 @@
 # Welcome to the `ethstaker-deposit-cli`!
 
-The [`ethstaker-deposit-cli`](https://github.com/eth-educators/ethstaker-deposit-cli) is a command-line tool used to generate validator keys forked from Ethereum's [`staking-deposit-cli`](https://github.com/ethereum/staking-deposit-cli) with more functionality and improved performance.
+The [`ethstaker-deposit-cli`](https://github.com/ethstaker/ethstaker-deposit-cli) is a command-line tool used to generate validator keys forked from Ethereum's [`staking-deposit-cli`](https://github.com/ethereum/staking-deposit-cli) with more functionality and improved performance.
 
 ## Security reports
 

--- a/docs/src/local_development.md
+++ b/docs/src/local_development.md
@@ -21,7 +21,7 @@ On Windows, you'll need:
 1. **Clone the Repository**
 
     ```sh
-    git clone https://github.com/eth-educators/ethstaker-deposit-cli.git
+    git clone https://github.com/ethstaker/ethstaker-deposit-cli.git
     ```
 
 2. **Navigate to the Project Directory**

--- a/docs/src/other_install_options.md
+++ b/docs/src/other_install_options.md
@@ -112,7 +112,7 @@
     Run the following command to pull the latest docker image published on the Github repository:
 
     ```sh
-    docker pull ghcr.io/eth-educators/ethstaker-deposit-cli:latest
+    docker pull ghcr.io/ethstaker/ethstaker-deposit-cli:latest
     ```
 
 2. **Create keys and `deposit_data-*.json`**
@@ -120,19 +120,19 @@
     Run the following command to enter the interactive CLI:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/eth-educators/ethstaker-deposit-cli:latest
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest
     ```
 
     You can also run the tool with optional arguments:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/eth-educators/ethstaker-deposit-cli:latest new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
     ```
 
     Example for 1 validator on the [Holesky testnet](https://holesky.launchpad.ethereum.org/) using english:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/eth-educators/ethstaker-deposit-cli:latest new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
     ```
 
 ### Option 4. Use local docker image
@@ -150,19 +150,19 @@
     Run the following command to enter the interactive CLI:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys eth-educators/ethstaker-deposit-cli
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli
     ```
 
     You can also run the tool with optional arguments:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys eth-educators/ethstaker-deposit-cli new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
     ```
 
     Example for 1 validator on the [Holesky testnet](https://holesky.launchpad.ethereum.org/) using english:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys eth-educators/ethstaker-deposit-cli new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
     ```
 
 ----

--- a/docs/src/quick_setup.md
+++ b/docs/src/quick_setup.md
@@ -11,7 +11,7 @@ This guide will walk you through the steps to download and set up the `ethstaker
 
 ### Download binary executable file
 
-1. Navigate to the [Releases page](https://github.com/eth-educators/ethstaker-deposit-cli/releases) of the `ethstaker-deposit-cli` repository.
+1. Navigate to the [Releases page](https://github.com/ethstaker/ethstaker-deposit-cli/releases) of the `ethstaker-deposit-cli` repository.
 
 2. Download the corresponding file for your operating system:
     - **Windows**: Look for a file with `windows` in the name.
@@ -31,7 +31,7 @@ For other installation options, including building with python or virtualenv and
 
 2. Verify the attestation against the corresponding file but be sure to replace the contents with the exact file name:
 ```sh
-gh attestation verify ethstaker_deposit-cli-*******-***.*** --repo eth-educators/ethstaker-deposit-cli
+gh attestation verify ethstaker_deposit-cli-*******-***.*** --repo ethstaker/ethstaker-deposit-cli
 ```
 
 This step requires you to be online. If you want to perform this offline, follow [these instructions from GitHub](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).
@@ -64,4 +64,4 @@ Determine which command best suits what you would like to accomplish:
 
 ---
 
-If you encounter any issues, please check the [issues page](https://github.com/eth-educators/ethstaker-deposit-cli/issues) for help or to report a problem. You may also contact us on the [Ethstaker discord](https://dsc.gg/ethstaker).
+If you encounter any issues, please check the [issues page](https://github.com/ethstaker/ethstaker-deposit-cli/issues) for help or to report a problem. You may also contact us on the [Ethstaker discord](https://dsc.gg/ethstaker).

--- a/docs/src/release_process.md
+++ b/docs/src/release_process.md
@@ -1,8 +1,8 @@
 # Release Process Instructions
 
-This document is meant as a guide on how to perform and publish a new release version of [ethstaker-deposit-cli](https://github.com/eth-educators/ethstaker-deposit-cli). It includes step by step instructions to complete the release process.
+This document is meant as a guide on how to perform and publish a new release version of [ethstaker-deposit-cli](https://github.com/ethstaker/ethstaker-deposit-cli). It includes step by step instructions to complete the release process.
 
-1. Make sure all the tests from the latest [ci-runner workflow](https://github.com/eth-educators/ethstaker-deposit-cli/actions/workflows/runner.yml) on the latest commit of the main branch are completed. Make sure all tests are passing on all the supported platforms.
+1. Make sure all the tests from the latest [ci-runner workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/runner.yml) on the latest commit of the main branch are completed. Make sure all tests are passing on all the supported platforms.
 2. Determine a new version number. Version numbers should adhere to [Semantic Versioning](https://semver.org/). For any official release, it should include a major, a minor and a patch identifier like `1.0.0`.
 3. Update `ethstaker_deposit/__init__.py`'s `__version__` variable with the new version number. Commit this change to the main branch of the main repository.
 4. Add a tag to the main repository for this changed version commit above. The name of this tag should be a string starting with `v` concatenated with the version number. With git, the main repository cloned and the commit above being the head, it can look like this:
@@ -10,7 +10,7 @@ This document is meant as a guide on how to perform and publish a new release ve
 git tag -a -m 'Version 1.0.0' v1.0.0
 git push origin v1.0.0
 ```
-5. Wait for all the build assets and the draft release to be created by [the ci-build workflow](https://github.com/eth-educators/ethstaker-deposit-cli/actions/workflows/build.yml).
+5. Wait for all the build assets and the draft release to be created by [the ci-build workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/build.yml).
 6. Open the draft release and fill in the different sections correctly.
 7. If this is not a production release, check the *Set as a pre-release* checkbox.
 8. Click the *Publish release* button.
@@ -19,4 +19,4 @@ git push origin v1.0.0
 
 ## Release Notes Template
 
-You can find the latest release notes template on https://github.com/eth-educators/ethstaker-deposit-cli/blob/main/.github/release_template.md .
+You can find the latest release notes template on https://github.com/ethstaker/ethstaker-deposit-cli/blob/main/.github/release_template.md .

--- a/docs/src/reporting_vulnerability.md
+++ b/docs/src/reporting_vulnerability.md
@@ -1,3 +1,3 @@
 # Reporting a Vulnerability
 
-Private vulnerability reporting is enabled on [the ethstaker-deposit-cli repository](https://github.com/eth-educators/ethstaker-deposit-cli). Feel free to report any security vulnerability through [the GitHub *Report a vulnerability* feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+Private vulnerability reporting is enabled on [the ethstaker-deposit-cli repository](https://github.com/ethstaker/ethstaker-deposit-cli). Feel free to report any security vulnerability through [the GitHub *Report a vulnerability* feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/eth-educators/ethstaker-deposit-cli"
+"Homepage" = "https://github.com/ethstaker/ethstaker-deposit-cli"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
**What I did**

Change all references of eth-educators to ethstaker

This should get a close review to make sure it doesn't break anything

We likely want a new release after, so that the official Docker image link goes to `ghcr.io/ethstaker/ethstaker-deposit-cli`
