### PR TITLE
Add backports.asyncio.runner for Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "mypy==1.16.1",
     "pytest==8.4.1",
     "pytest-asyncio==1.0.0",
+    "backports-asyncio-runner==1.2.0 ; python_version < '3.11'",
     "coverage==7.9.2",
     "tomli==2.2.1",
     "attrs==25.3.0",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -129,6 +129,9 @@ pytest==8.4.1 \
 pytest-asyncio==1.0.0 \
     --hash=sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3 \
     --hash=sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f
+backports.asyncio.runner==1.2.0 ; python_version < '3.11' \
+    --hash=sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5 \
+    --hash=sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \
     --hash=sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0


### PR DESCRIPTION
**What I did**

Add backports.asyncio.runner to test requirements with hash, so that the dependabot update in 381 can succeed
