### PR TITLE
Allow tests to work with click 8.3.0

### DIFF
--- a/tests/test_cli/test_partial_deposit.py
+++ b/tests/test_cli/test_partial_deposit.py
@@ -57,7 +57,7 @@ def test_partial_deposit(amount: str) -> None:
 
     runner = CliRunner()
     inputs = ['english', 'mainnet', password, amount, withdrawal_address, withdrawal_address, '']
-    data = '\n'.join(inputs)
+    data = '\n'.join(inputs) + '\n'
     arguments = [
         '--ignore_connectivity',
         'partial-deposit',


### PR DESCRIPTION
**What I did**

Add a final newline to the partial deposit tests, to work with Click 8.3.0's changed behavior