### PR TITLE
Dependabot cooldown of 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
+    cooldown:
+      default-days: "7"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -17,6 +19,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
+    cooldown:
+      default-days: "7"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -25,6 +29,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: "7"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -33,6 +39,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "uv"
+    cooldown:
+      default-days: "7"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
**What I did**

To defend against supply-chain attacks, put dependabot on a default 7-day cooldown
