### PR TITLE
Changing cooldown from a string to an integer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     cooldown:
-      default-days: "7"
+      default-days: 7
     directory: "/"
     schedule:
       interval: "weekly"
@@ -20,7 +20,7 @@ updates:
           - "*"
   - package-ecosystem: "docker"
     cooldown:
-      default-days: "7"
+      default-days: 7
     directory: "/"
     schedule:
       interval: "weekly"
@@ -30,7 +30,7 @@ updates:
           - "*"
   - package-ecosystem: "github-actions"
     cooldown:
-      default-days: "7"
+      default-days: 7
     directory: "/"
     schedule:
       interval: "weekly"
@@ -40,7 +40,7 @@ updates:
           - "*"
   - package-ecosystem: "uv"
     cooldown:
-      default-days: "7"
+      default-days: 7
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I duplicated this change in staker-console and saw an error saying that cooldown has to be an integer, not a string. I changed it there which resolved the issue so now I'm changing it here.