### PR TITLE
test: expand BLS-to-execution-change coverage

### DIFF
--- a/tests/test_cli/test_generate_bls_to_execution_change.py
+++ b/tests/test_cli/test_generate_bls_to_execution_change.py
@@ -3,13 +3,72 @@ import json
 
 from click.testing import CliRunner
 
+from ethstaker_deposit.credentials import Credential
 from ethstaker_deposit.deposit import cli
-from ethstaker_deposit.utils.constants import DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME
+from ethstaker_deposit.settings import DEPOSIT_CLI_VERSION, BaseChainSetting, MainnetSetting
+from ethstaker_deposit.utils.constants import DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME, ETH2GWEI
+from ethstaker_deposit.utils.validation import verify_bls_to_execution_change_json
 from .helpers import (
     clean_btec_folder,
     prepare_testing_folder,
+    read_json_file,
     verify_file_permission,
 )
+
+TEST_MNEMONIC = (
+    'sister protect peanut hill ready work profit fit wish want small inflict flip member tail between sick '
+    'setup bright duck morning sell paper worry'
+)
+
+
+def assert_btec_content(
+        folder_path: str,
+        expected_validator_indices: list[int],
+        expected_network: str = 'mainnet',
+        expected_withdrawal_address: str = '0x3434343434343434343434343434343434343434',
+) -> str:
+    _, _, btec_files = next(os.walk(folder_path))
+    assert len(btec_files) == 1
+    btec_data = read_json_file(folder_path, btec_files[0])
+    assert [int(change['message']['validator_index']) for change in btec_data] == expected_validator_indices
+    for change in btec_data:
+        assert change['message']['from_bls_pubkey'].startswith('0x')
+        assert len(change['message']['from_bls_pubkey']) == 2 + 48 * 2
+        assert change['message']['to_execution_address'] == expected_withdrawal_address.lower()
+        assert len(change['signature']) == 2 + 96 * 2
+        assert change['metadata']['network_name'] == expected_network
+        assert change['metadata']['deposit_cli_version'] == DEPOSIT_CLI_VERSION
+        assert len(change['metadata']['genesis_validators_root']) == 2 + 32 * 2
+    return os.path.join(folder_path, btec_files[0])
+
+
+def assert_btec_round_trip(
+        filefolder: str,
+        *,
+        mnemonic: str,
+        start_index: int,
+        validator_indices: list[int],
+        withdrawal_address: str,
+        chain_setting: BaseChainSetting,
+) -> None:
+    credentials = [
+        Credential(
+            mnemonic=mnemonic,
+            mnemonic_password='',
+            index=index,
+            amount=chain_setting.MIN_ACTIVATION_AMOUNT * chain_setting.MULTIPLIER * ETH2GWEI,
+            chain_setting=chain_setting,
+            hex_withdrawal_address=withdrawal_address,
+        )
+        for index in range(start_index, start_index + len(validator_indices))
+    ]
+    assert verify_bls_to_execution_change_json(
+        filefolder,
+        credentials,
+        input_validator_indices=validator_indices,
+        input_withdrawal_address=withdrawal_address,
+        chain_setting=chain_setting,
+    )
 
 
 def test_existing_mnemonic_bls_withdrawal() -> None:
@@ -38,8 +97,15 @@ def test_existing_mnemonic_bls_withdrawal() -> None:
     bls_to_execution_changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME)
     _, _, btec_files = next(os.walk(bls_to_execution_changes_folder_path))
 
-    # TODO verify file content
-    assert len(set(btec_files)) == 1
+    btec_file = assert_btec_content(bls_to_execution_changes_folder_path, [1])
+    assert_btec_round_trip(
+        btec_file,
+        mnemonic=TEST_MNEMONIC,
+        start_index=0,
+        validator_indices=[1],
+        withdrawal_address='0x3434343434343434343434343434343434343434',
+        chain_setting=MainnetSetting,
+    )
 
     # Verify file permissions
     verify_file_permission(os, folder_path=bls_to_execution_changes_folder_path, files=btec_files)
@@ -77,8 +143,7 @@ def test_existing_mnemonic_bls_withdrawal_interactive() -> None:
     bls_to_execution_changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME)
     _, _, btec_files = next(os.walk(bls_to_execution_changes_folder_path))
 
-    # TODO verify file content
-    assert len(set(btec_files)) == 1
+    assert_btec_content(bls_to_execution_changes_folder_path, [1])
 
     # Verify file permissions
     verify_file_permission(os, folder_path=bls_to_execution_changes_folder_path, files=btec_files)
@@ -113,8 +178,15 @@ def test_existing_mnemonic_bls_withdrawal_multiple() -> None:
     bls_to_execution_changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME)
     _, _, btec_files = next(os.walk(bls_to_execution_changes_folder_path))
 
-    # TODO verify file content
-    assert len(set(btec_files)) == 1
+    btec_file = assert_btec_content(bls_to_execution_changes_folder_path, [1, 2])
+    assert_btec_round_trip(
+        btec_file,
+        mnemonic=TEST_MNEMONIC,
+        start_index=0,
+        validator_indices=[1, 2],
+        withdrawal_address='0x3434343434343434343434343434343434343434',
+        chain_setting=MainnetSetting,
+    )
 
     # Verify file permissions
     verify_file_permission(os, folder_path=bls_to_execution_changes_folder_path, files=btec_files)
@@ -158,8 +230,26 @@ def test_bls_change_custom_testnet() -> None:
     bls_to_execution_changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME)
     _, _, btec_files = next(os.walk(bls_to_execution_changes_folder_path))
 
-    # TODO verify file content
-    assert len(set(btec_files)) == 1
+    btec_file = assert_btec_content(
+        bls_to_execution_changes_folder_path,
+        [1],
+        expected_network='hoodicopy',
+    )
+    assert_btec_round_trip(
+        btec_file,
+        mnemonic=TEST_MNEMONIC,
+        start_index=0,
+        validator_indices=[1],
+        withdrawal_address='0x3434343434343434343434343434343434343434',
+        chain_setting=BaseChainSetting(
+            NETWORK_NAME='hoodicopy',
+            GENESIS_FORK_VERSION=bytes.fromhex('20000910'),
+            EXIT_FORK_VERSION=bytes.fromhex('04017000'),
+            GENESIS_VALIDATORS_ROOT=bytes.fromhex(
+                '212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f'
+            ),
+        ),
+    )
 
     # Verify file permissions
     verify_file_permission(os, folder_path=bls_to_execution_changes_folder_path, files=btec_files)

--- a/tests/test_utils/test_validation_bls_to_execution_change.py
+++ b/tests/test_utils/test_validation_bls_to_execution_change.py
@@ -1,0 +1,117 @@
+from copy import deepcopy
+
+import pytest
+
+from ethstaker_deposit.credentials import Credential
+from ethstaker_deposit.exceptions import ValidationError
+from ethstaker_deposit.settings import EphemerySetting, MainnetSetting
+from ethstaker_deposit.utils.validation import validate_bls_to_execution_change
+
+
+MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+ADDRESS = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+
+
+@pytest.fixture
+def btec_case() -> tuple[Credential, dict[str, object]]:
+    credential = Credential(
+        mnemonic=MNEMONIC,
+        mnemonic_password='',
+        index=0,
+        amount=32 * 10**9,
+        chain_setting=MainnetSetting,
+        hex_withdrawal_address=ADDRESS,
+    )
+    return credential, credential.get_bls_to_execution_change_dict(validator_index=7)
+
+
+def test_validate_bls_to_execution_change_accepts_generated_change(btec_case) -> None:
+    credential, btec = btec_case
+    assert validate_bls_to_execution_change(
+        btec,
+        credential,
+        input_validator_index=7,
+        input_withdrawal_address=ADDRESS,
+        chain_setting=MainnetSetting,
+    )
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('validator_index', '8'),
+        ('from_bls_pubkey', '0x' + '11' * 48),
+        ('to_execution_address', '0x' + '22' * 20),
+    ],
+)
+def test_validate_bls_to_execution_change_rejects_message_mismatch(btec_case, field, value) -> None:
+    credential, btec = btec_case
+    changed = deepcopy(btec)
+    changed['message'][field] = value
+    assert not validate_bls_to_execution_change(
+        changed,
+        credential,
+        input_validator_index=7,
+        input_withdrawal_address=ADDRESS,
+        chain_setting=MainnetSetting,
+    )
+
+
+def test_validate_bls_to_execution_change_rejects_wrong_input_address(btec_case) -> None:
+    credential, btec = btec_case
+    assert not validate_bls_to_execution_change(
+        btec,
+        credential,
+        input_validator_index=7,
+        input_withdrawal_address='0x1111111111111111111111111111111111111111',
+        chain_setting=MainnetSetting,
+    )
+
+
+def test_validate_bls_to_execution_change_rejects_wrong_root_or_signature(btec_case) -> None:
+    credential, btec = btec_case
+    wrong_root = deepcopy(btec)
+    wrong_root['metadata']['genesis_validators_root'] = '0x' + '00' * 32
+    assert not validate_bls_to_execution_change(
+        wrong_root,
+        credential,
+        input_validator_index=7,
+        input_withdrawal_address=ADDRESS,
+        chain_setting=MainnetSetting,
+    )
+
+    wrong_signature = deepcopy(btec)
+    wrong_signature['signature'] = '0x' + '00' * 96
+    assert not validate_bls_to_execution_change(
+        wrong_signature,
+        credential,
+        input_validator_index=7,
+        input_withdrawal_address=ADDRESS,
+        chain_setting=MainnetSetting,
+    )
+
+
+def test_get_bls_to_execution_change_rejects_missing_withdrawal_address() -> None:
+    credential = Credential(
+        mnemonic=MNEMONIC,
+        mnemonic_password='',
+        index=0,
+        amount=32 * 10**9,
+        chain_setting=MainnetSetting,
+        hex_withdrawal_address=None,
+    )
+    with pytest.raises(ValueError, match='withdrawal address should NOT be empty'):
+        credential.get_bls_to_execution_change(validator_index=7)
+
+
+def test_get_bls_to_execution_change_rejects_missing_genesis_root() -> None:
+    credential = Credential(
+        mnemonic=MNEMONIC,
+        mnemonic_password='',
+        index=0,
+        amount=32 * 10**9,
+        chain_setting=EphemerySetting,
+        hex_withdrawal_address=ADDRESS,
+    )
+    with pytest.raises(ValidationError, match='genesis validators root should NOT be empty'):
+        credential.get_bls_to_execution_change(validator_index=7)


### PR DESCRIPTION
**What I did**

Adds comprehensive BLS-to-execution-change coverage, including serialized JSON assertions, cryptographic round-trip validation, multi-validator and custom-network cases, tamper detection, and missing-configuration error handling.

Created by GPT 5.6
