### PR TITLE
Fix: coverage comment

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,6 +1,9 @@
 # Safely comment on the PR - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 name: ci-comment
 run-name: ${{ github.actor }} is adding coverage report comment on PR
+concurrency:
+  group: ci-comment-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
 on:
   workflow_run:
     workflows: [ "ci-runner" ]
@@ -11,7 +14,7 @@ jobs:
   completed-coverage:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: read
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
@@ -57,9 +60,8 @@ jobs:
     # Runs only if we have a completed coverage job from the ci-runner workflow
     if: ${{ needs.completed-coverage.outputs.coverage == 'completed' }}
     permissions:
+      actions: read
       issues: write
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -74,16 +76,44 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            var fs = require('fs');
-            const issueNumberPath = './issue_number'
-            if (!fs.existsSync(issueNumberPath)) {
-              console.log("Coverage artifacts were not downloaded, succeeding early");
-              return;
+            const fs = require('fs');
+            const pullRequest = context.payload.workflow_run.pull_requests?.[0];
+            if (!pullRequest?.number) {
+              throw new Error('Could not determine the pull request number from the workflow run event');
             }
-            var issueNumber = Number(fs.readFileSync(issueNumberPath));
-            await github.rest.issues.createComment({
+
+            const issueNumber = pullRequest.number;
+            const marker = '<!-- ethstaker-coverage-report -->';
+            const reportPath = './coverage-text-report';
+            if (!fs.existsSync(reportPath)) {
+              throw new Error('Coverage report artifact was not downloaded');
+            }
+
+            const body = `${marker}\n${fs.readFileSync(reportPath).toString()}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: fs.readFileSync('./coverage-text-report').toString()
+              per_page: 100,
             });
+            const existingComment = comments.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -2,7 +2,7 @@
 name: ci-comment
 run-name: ${{ github.actor }} is adding coverage report comment on PR
 concurrency:
-  group: ci-comment-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: ci-comment-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: true
 on:
   workflow_run:
@@ -62,6 +62,7 @@ jobs:
     permissions:
       actions: read
       issues: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -77,12 +78,26 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const pullRequest = context.payload.workflow_run.pull_requests?.[0];
-            if (!pullRequest?.number) {
-              throw new Error('Could not determine the pull request number from the workflow run event');
+            const workflowRun = context.payload.workflow_run;
+            const headRepository = workflowRun.head_repository?.full_name;
+            const headBranch = workflowRun.head_branch;
+            if (!headRepository || !headBranch) {
+              throw new Error('Could not determine the workflow run head repository and branch');
             }
 
-            const issueNumber = pullRequest.number;
+            const [headOwner] = headRepository.split('/');
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              head: `${headOwner}:${headBranch}`,
+              per_page: 100,
+            });
+            if (pullRequests.length === 0) {
+              throw new Error(`Could not find a pull request for ${headRepository}:${headBranch}`);
+            }
+
+            const issueNumber = pullRequests[0].number;
             const marker = '<!-- ethstaker-coverage-report -->';
             const reportPath = './coverage-text-report';
             if (!fs.existsSync(reportPath)) {

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -16,9 +16,10 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     outputs:
-      coverage: ${{ steps.output.outputs.coverage }}
+      coverage: ${{ steps.coverage.outputs.coverage }}
     steps:
       - name: Get coverage job success
+        id: coverage
         uses: actions/github-script@v9
         env:
           WORKFLOW_RUN_ID: '${{ github.event.workflow_run.id }}'
@@ -27,7 +28,7 @@ jobs:
           script: |
             const { WORKFLOW_RUN_ID } = process.env;
 
-            core.exportVariable('COVERAGE', 'unknown');
+            let coverage = 'unknown';
 
             const allJobs = await github.paginate(
               github.rest.actions.listJobsForWorkflowRun,
@@ -45,13 +46,12 @@ jobs:
                 job.status == 'completed' &&
                 job.conclusion == 'success'
               ) {
-                core.exportVariable('COVERAGE', 'completed');
+                coverage = 'completed';
                 break;
               }
-            });
-      - name: Output coverage status
-        id: output
-        run: echo "coverage=${COVERAGE}" >> "$GITHUB_OUTPUT"
+            }
+
+            core.setOutput('coverage', coverage);
   comment:
     needs: completed-coverage
     # Runs only if we have a completed coverage job from the ci-runner workflow

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -29,19 +29,24 @@ jobs:
 
             core.exportVariable('COVERAGE', 'unknown');
 
-            const { data: allJobs } = await github.rest.actions.listJobsForWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: WORKFLOW_RUN_ID,
-            });
+            const allJobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: WORKFLOW_RUN_ID,
+                per_page: 100,
+              }
+            );
 
-            allJobs.jobs.forEach((job) => {
+            for (const job of allJobs) {
               if (
                 job.name === 'coverage-combine' &&
                 job.status == 'completed' &&
                 job.conclusion == 'success'
               ) {
                 core.exportVariable('COVERAGE', 'completed');
+                break;
               }
             });
       - name: Output coverage status

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -114,7 +114,6 @@ jobs:
             coverage report ;
             echo \`\`\` ;
           } >> results/coverage-text-report
-          echo ${{ github.event.number }} > results/issue_number
       - name: Upload final coverage text report
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,8 @@
 name: ci-runner
 run-name: ${{ github.actor }} is testing and measuring code quality
+concurrency:
+  group: ci-runner-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
**What I did**

I have more than 30 jobs, so I need to paginate or at the very least increase the per-page output, for coverage comment to see the completed `coverage-combine`

I don't need to set a variable and then set output: I can just set output. I only have one more job consuming that, anyway: The comment job

Workflow has been hardened: Only required write permissions, and a malicious PR can no longer update things it shouldn't

Test runs will be cancelled now when pushing to the same PR again, ditto when merging to main again. This speeds up testing.

Unfortunately the new `comment.yml` needs to be on  `main` before we can know whether this fix was successful

Fixes #466 
