### PR TITLE
CI uses macos-26-intel

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest, windows-11-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest, windows-latest, windows-11-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - os: windows-11-arm


### PR DESCRIPTION
**What I did**

Have CI use `macos-26-intel` instead of `macos-15-intel`.

Run tests on this after #590 is in, to see whether the coverage comment fix works
