### PR TITLE
Fix coverage comment permissions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       actions: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts


### PR DESCRIPTION
**What I did**

Coverage comment needs PR write after all, even as comments use the issues API
