### PR TITLE
test: cover credential and exit edge cases

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5,9 +5,9 @@ import stat
 import pytest
 from py_ecc.bls import G2ProofOfPossession as bls
 
-from ethstaker_deposit.credentials import Credential, CredentialList
+from ethstaker_deposit.credentials import Credential, CredentialList, WithdrawalType
 from ethstaker_deposit.key_handling.keystore import Keystore
-from ethstaker_deposit.settings import DEPOSIT_CLI_VERSION, MainnetSetting
+from ethstaker_deposit.settings import DEPOSIT_CLI_VERSION, MainnetSetting, HoodiSetting
 from ethstaker_deposit.utils.constants import (
     BLS_WITHDRAWAL_PREFIX,
     COMPOUNDING_WITHDRAWAL_PREFIX,
@@ -142,18 +142,54 @@ def test_credential_withdrawal_credentials_variants() -> None:
     compounding_credential = make_credential(compounding=True)
 
     assert bls_credential.withdrawal_prefix == BLS_WITHDRAWAL_PREFIX
-    assert bls_credential.withdrawal_type.name == 'BLS_WITHDRAWAL'
+    assert bls_credential.withdrawal_type is WithdrawalType.BLS_WITHDRAWAL
     assert len(bls_credential.withdrawal_credentials) == 32
     assert bls_credential.withdrawal_credentials[1:] == SHA256(bls_credential.withdrawal_pk)[1:]
 
     assert execution_credential.withdrawal_prefix == EXECUTION_ADDRESS_WITHDRAWAL_PREFIX
+    assert execution_credential.withdrawal_type is WithdrawalType.EXECUTION_ADDRESS_WITHDRAWAL
     assert execution_credential.withdrawal_credentials == (
         EXECUTION_ADDRESS_WITHDRAWAL_PREFIX + b'\x00' * 11 + execution_credential.withdrawal_address
     )
     assert compounding_credential.withdrawal_prefix == COMPOUNDING_WITHDRAWAL_PREFIX
+    assert compounding_credential.withdrawal_type is WithdrawalType.COMPOUNDING_WITHDRAWAL
     assert compounding_credential.withdrawal_credentials == (
         COMPOUNDING_WITHDRAWAL_PREFIX + b'\x00' * 11 + compounding_credential.withdrawal_address
     )
+
+
+def test_credential_public_keys_are_stable_and_valid() -> None:
+    credential = make_credential()
+
+    assert credential.signing_pk == make_credential().signing_pk
+    assert credential.withdrawal_pk == make_credential().withdrawal_pk
+    assert len(credential.signing_pk) == 48
+    assert len(credential.withdrawal_pk) == 48
+    assert bls.KeyValidate(credential.signing_pk)
+    assert bls.KeyValidate(credential.withdrawal_pk)
+
+
+def test_withdrawal_address_is_canonical_bytes() -> None:
+    credential = make_credential()
+
+    assert credential.withdrawal_address == bytes.fromhex(WITHDRAWAL_ADDRESS[2:].lower())
+    assert len(credential.withdrawal_address) == 20
+
+
+def test_withdrawal_credentials_reject_invalid_withdrawal_state() -> None:
+    credential = make_credential()
+    credential.hex_withdrawal_address = None
+    credential.compounding = True
+
+    assert credential.withdrawal_type is WithdrawalType.BLS_WITHDRAWAL
+    assert credential.withdrawal_credentials.startswith(BLS_WITHDRAWAL_PREFIX)
+
+
+def test_bls_to_execution_change_requires_withdrawal_address() -> None:
+    credential = make_credential(address=None)
+
+    with pytest.raises(ValueError, match='withdrawal address should NOT be empty'):
+        credential.get_bls_to_execution_change(validator_index=7)
 
 
 def test_signed_deposit_and_datum_validate() -> None:
@@ -208,3 +244,33 @@ def test_save_exit_transaction_writes_signed_json(tmp_path) -> None:
     )
     signed_exit = SignedVoluntaryExit(message=message, signature=bytes.fromhex(result['signature'][2:]))
     assert bls.Verify(credential.signing_pk, compute_signing_root(message, domain), signed_exit.signature)
+
+
+def test_save_exit_transaction_uses_non_mainnet_domain_and_restrictive_permissions(tmp_path) -> None:
+    credential = Credential(
+        mnemonic=MNEMONIC,
+        mnemonic_password='',
+        index=0,
+        amount=32 * ETH2GWEI,
+        chain_setting=HoodiSetting,
+        hex_withdrawal_address=None,
+    )
+    filepath = credential.save_exit_transaction(
+        validator_index=7,
+        epoch=42,
+        folder=str(tmp_path),
+        timestamp=1234567890,
+    )
+
+    if os.name == 'posix':
+        assert stat.S_IMODE(os.stat(filepath).st_mode) == 0o400
+    with open(filepath, encoding='utf-8') as file:
+        result = json.load(file)
+
+    message = VoluntaryExit(epoch=42, validator_index=7)
+    domain = compute_voluntary_exit_domain(
+        HoodiSetting.EXIT_FORK_VERSION,
+        HoodiSetting.GENESIS_VALIDATORS_ROOT,
+    )
+    signature = bytes.fromhex(result['signature'][2:])
+    assert bls.Verify(credential.signing_pk, compute_signing_root(message, domain), signature)


### PR DESCRIPTION
**What I did**

## Summary

Expand credential and exit transaction edge-case coverage.

## Changes

- Verify stable, valid signing and withdrawal public keys.
- Assert canonical withdrawal-address bytes and withdrawal types.
- Cover invalid withdrawal-state and missing-address behavior.
- Validate exit transaction signatures on Hoodi using the correct domain.
- Assert restrictive `0o400` permissions for exported exit transactions on `posix` only, as Windows doesn't use that permission model. Windows continues to validate exit transaction output and cryptographic correctness without relying on POSIX permission bits.

## Testing

- `978 passed`
- Ruff passed
- Python version check passed

Created by GPT 5.6

**Related issue**

Part of #144 . Two more to go

