### PR TITLE
chore: validate cached keystore key lengths early

### DIFF
--- a/ethstaker_deposit/key_handling/keystore.py
+++ b/ethstaker_deposit/key_handling/keystore.py
@@ -170,6 +170,10 @@ class Keystore(BytesDataclass):
         """
         if (kdf_salt is None) != (decryption_key is None):
             raise ValueError("kdf_salt and decryption_key must either both be set or both be None")
+        if kdf_salt is not None and len(kdf_salt) != 32:
+            raise ValueError("kdf_salt must be 32 bytes")
+        if decryption_key is not None and len(decryption_key) != 32:
+            raise ValueError("decryption_key must be 32 bytes")
         if 'salt' not in self.crypto.kdf.params:
             raise ValueError("Missing kdf salt on decryption")
         decryption_key = self._get_decryption_key(password, kdf_salt=kdf_salt, decryption_key=decryption_key)

--- a/tests/test_key_handling/test_keystore.py
+++ b/tests/test_key_handling/test_keystore.py
@@ -68,6 +68,21 @@ def test_encrypt_decrypt_incorrect_password() -> None:
 
 
 @pytest.mark.parametrize(
+    'kdf_salt, decryption_key',
+    [
+        (b'\x00' * 31, b'\x00' * 32),
+        (b'\x00' * 33, b'\x00' * 32),
+        (b'\x00' * 32, b'\x00' * 31),
+        (b'\x00' * 32, b'\x00' * 33),
+    ],
+)
+def test_decrypt_rejects_invalid_cached_key_lengths(kdf_salt: bytes, decryption_key: bytes) -> None:
+    generated_keystore = ScryptKeystore.encrypt(secret=test_vector_secret, password=test_vector_password)
+    with pytest.raises(ValueError):
+        generated_keystore.decrypt(test_vector_password, kdf_salt, decryption_key)
+
+
+@pytest.mark.parametrize(
     'password,processed_password',
     [
         ['\a', b''], ['\b', b''], ['\t', b''],


### PR DESCRIPTION
**What I did**

Check length of `kdf_salt` and `decryption_key` early, before doing any KDF work. This had been suggested by ToB. It's a small change and we "may as well", but it has no impact on time spent running tests, or on production use: In production we control things end to end and the length is always 32 bytes.

**Related issue**

closes #497 
