### PR TITLE
Fix: Translation check CI

### DIFF
--- a/ethstaker_deposit/intl/ar/utils/validation.json
+++ b/ethstaker_deposit/intl/ar/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "يستخدم إعداد شبكة التطوير إصدار تفرّع نشأة معروفًا من شبكة موجودة.",
     "err_devnet_chain_setting_invalid_json": "سلسلة JSON الخاصة بـ devnet_chain_setting غير صالحة. تعذّر فك ترميز سلسلة JSON. تأكد من تمرير سلسلة JSON صالحة.",
     "err_devnet_chain_setting_unknown_keys": "يحتوي إعداد شبكة التطوير على مفاتيح غير معروفة.",
-    "err_devnet_chain_setting_negative_multiplier": "قيمة المُضاعف في إعداد شبكة التطوير غير صالحة. لا يمكن أن تكون سالبة.",
     "err_devnet_chain_setting_too_large": "سلسلة JSON الخاصة بـ devnet_chain_setting غير صالحة. إنها تتجاوز الحد الأقصى للحجم.",
     "err_devnet_chain_setting_invalid_network_name": "network_name غير صالح في إعداد شبكة التطوير. يجب أن يكون سلسلة غير فارغة.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version غير صالح في إعداد شبكة التطوير. يجب أن يكون 4 بايت بالضبط بصيغة سداسية عشرية.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version غير صالح في إعداد شبكة التطوير. يجب أن يكون 4 بايت بالضبط بصيغة سداسية عشرية.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root غير صالح في إعداد شبكة التطوير. يجب أن يكون 32 بايت بالضبط بصيغة سداسية عشرية.",
     "err_devnet_chain_setting_invalid_number": "القيمة الرقمية في إعداد شبكة التطوير غير صالحة.",
-    "err_devnet_chain_setting_positive_number": "يجب أن تكون القيم الرقمية في إعداد شبكة التطوير موجبة."
+    "err_devnet_chain_setting_positive_number": "يجب أن تكون القيم الرقمية في إعداد شبكة التطوير موجبة.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version غير صالح في إعداد شبكة التطوير. يجب أن يكون 4 بايت بالضبط بصيغة سداسية عشرية.",
+      "invalid_exit_fork_version": "exit_fork_version غير صالح في إعداد شبكة التطوير. يجب أن يكون 4 بايت بالضبط بصيغة سداسية عشرية.",
+      "invalid_genesis_validator_root": "genesis_validator_root غير صالح في إعداد شبكة التطوير. يجب أن يكون 32 بايت بالضبط بصيغة سداسية عشرية."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "يفتقد إعداد السلسلة قيمة GENESIS_VALIDATORS_ROOT. هذه القيمة مطلوبة لإنشاء معاملة الخروج."

--- a/ethstaker_deposit/intl/de/utils/validation.json
+++ b/ethstaker_deposit/intl/de/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Die Devnet-Chain-Einstellung verwendet eine bekannte Genesis-Fork-Version eines bestehenden Netzwerks.",
     "err_devnet_chain_setting_invalid_json": "Ungültiger JSON-String für devnet_chain_setting. Der JSON-String konnte nicht decodiert werden. Stellen Sie sicher, dass Sie einen gültigen JSON-String übergeben.",
     "err_devnet_chain_setting_unknown_keys": "Die Devnet-Chain-Einstellung enthält nicht erkannte Schlüssel.",
-    "err_devnet_chain_setting_negative_multiplier": "Ungültiger Multiplikatorwert in der Devnet-Chain-Einstellung. Er darf nicht negativ sein.",
     "err_devnet_chain_setting_too_large": "Ungültige JSON-Zeichenfolge für devnet_chain_setting. Sie überschreitet die maximale Größe.",
     "err_devnet_chain_setting_invalid_network_name": "Ungültiger network_name in der Devnet-Chain-Einstellung. Er muss eine nicht leere Zeichenfolge sein.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "Ungültiger genesis_fork_version in der Devnet-Chain-Einstellung. Er muss genau 4 Bytes im Hexadezimalformat umfassen.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "Ungültiger exit_fork_version in der Devnet-Chain-Einstellung. Er muss genau 4 Bytes im Hexadezimalformat umfassen.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "Ungültiger genesis_validator_root in der Devnet-Chain-Einstellung. Er muss genau 32 Bytes im Hexadezimalformat umfassen.",
     "err_devnet_chain_setting_invalid_number": "Ungültiger numerischer Wert in der Devnet-Chain-Einstellung.",
-    "err_devnet_chain_setting_positive_number": "Numerische Werte in der Devnet-Chain-Einstellung müssen positiv sein."
+    "err_devnet_chain_setting_positive_number": "Numerische Werte in der Devnet-Chain-Einstellung müssen positiv sein.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "Ungültiger genesis_fork_version in der Devnet-Chain-Einstellung. Er muss genau 4 Bytes im Hexadezimalformat umfassen.",
+      "invalid_exit_fork_version": "Ungültiger exit_fork_version in der Devnet-Chain-Einstellung. Er muss genau 4 Bytes im Hexadezimalformat umfassen.",
+      "invalid_genesis_validator_root": "Ungültiger genesis_validator_root in der Devnet-Chain-Einstellung. Er muss genau 32 Bytes im Hexadezimalformat umfassen."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "In den Chain-Einstellungen fehlt ein Wert für GENESIS_VALIDATORS_ROOT. Dieser Wert wird zum Erstellen der Exit-Transaktion benötigt."

--- a/ethstaker_deposit/intl/el/utils/validation.json
+++ b/ethstaker_deposit/intl/el/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Η ρύθμιση αλυσίδας devnet χρησιμοποιεί γνωστή έκδοση fork γένεσης από υπάρχον δίκτυο.",
     "err_devnet_chain_setting_invalid_json": "Μη έγκυρη συμβολοσειρά JSON για το devnet_chain_setting. Δεν ήταν δυνατή η αποκωδικοποίηση της συμβολοσειράς JSON. Βεβαιωθείτε ότι δώσατε έγκυρη συμβολοσειρά JSON.",
     "err_devnet_chain_setting_unknown_keys": "Η ρύθμιση αλυσίδας devnet περιέχει μη αναγνωρισμένα κλειδιά.",
-    "err_devnet_chain_setting_negative_multiplier": "Μη έγκυρη τιμή πολλαπλασιαστή στη ρύθμιση αλυσίδας devnet. Δεν μπορεί να είναι αρνητική.",
     "err_devnet_chain_setting_too_large": "Μη έγκυρη συμβολοσειρά JSON για devnet_chain_setting. Υπερβαίνει το μέγιστο μέγεθος.",
     "err_devnet_chain_setting_invalid_network_name": "Μη έγκυρο network_name στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι μη κενή συμβολοσειρά.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "Μη έγκυρο genesis_fork_version στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 4 byte σε δεκαεξαδική μορφή.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "Μη έγκυρο exit_fork_version στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 4 byte σε δεκαεξαδική μορφή.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "Μη έγκυρο genesis_validator_root στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 32 byte σε δεκαεξαδική μορφή.",
     "err_devnet_chain_setting_invalid_number": "Μη έγκυρη αριθμητική τιμή στη ρύθμιση αλυσίδας devnet.",
-    "err_devnet_chain_setting_positive_number": "Οι αριθμητικές τιμές στη ρύθμιση αλυσίδας devnet πρέπει να είναι θετικές."
+    "err_devnet_chain_setting_positive_number": "Οι αριθμητικές τιμές στη ρύθμιση αλυσίδας devnet πρέπει να είναι θετικές.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "Μη έγκυρο genesis_fork_version στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 4 byte σε δεκαεξαδική μορφή.",
+      "invalid_exit_fork_version": "Μη έγκυρο exit_fork_version στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 4 byte σε δεκαεξαδική μορφή.",
+      "invalid_genesis_validator_root": "Μη έγκυρο genesis_validator_root στη ρύθμιση αλυσίδας devnet. Πρέπει να είναι ακριβώς 32 byte σε δεκαεξαδική μορφή."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "Η ρύθμιση της αλυσίδας δεν περιέχει τιμή GENESIS_VALIDATORS_ROOT. Αυτή η τιμή απαιτείται για τη δημιουργία της συναλλαγής εξόδου."

--- a/ethstaker_deposit/intl/en/utils/validation.json
+++ b/ethstaker_deposit/intl/en/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "The devnet chain setting is using a known genesis fork version from an existing network.",
     "err_devnet_chain_setting_invalid_json": "Invalid JSON string for devnet_chain_setting. Decoding the JSON string was impossible. Make sure to pass a valid JSON string.",
     "err_devnet_chain_setting_unknown_keys": "The devnet chain setting contains unrecognized keys.",
-    "err_devnet_chain_setting_negative_multiplier": "Invalid multiplier value in devnet chain setting. It cannot be negative.",
     "err_devnet_chain_setting_too_large": "Invalid JSON string for devnet_chain_setting. It exceeds the maximum size.",
     "err_devnet_chain_setting_invalid_network_name": "Invalid network_name in devnet chain setting. It must be a non-empty string.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "Invalid genesis_fork_version in devnet chain setting. It must be exactly 4 bytes of hex.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "Invalid exit_fork_version in devnet chain setting. It must be exactly 4 bytes of hex.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "Invalid genesis_validator_root in devnet chain setting. It must be exactly 32 bytes of hex.",
     "err_devnet_chain_setting_invalid_number": "Invalid numeric value in devnet chain setting.",
-    "err_devnet_chain_setting_positive_number": "Numeric values in devnet chain setting must be positive."
+    "err_devnet_chain_setting_positive_number": "Numeric values in devnet chain setting must be positive.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "Invalid genesis_fork_version in devnet chain setting. It must be exactly 4 bytes of hex.",
+      "invalid_exit_fork_version": "Invalid exit_fork_version in devnet chain setting. It must be exactly 4 bytes of hex.",
+      "invalid_genesis_validator_root": "Invalid genesis_validator_root in devnet chain setting. It must be exactly 32 bytes of hex."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "The chain setting is missing a GENESIS_VALIDATORS_ROOT value. That value is needed to create the exit transaction."

--- a/ethstaker_deposit/intl/fr/utils/validation.json
+++ b/ethstaker_deposit/intl/fr/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Le paramètre de chaîne devnet utilise une version de fork de genèse connue provenant d'un réseau existant.",
     "err_devnet_chain_setting_invalid_json": "Chaîne JSON invalide pour devnet_chain_setting. Le décodage de la chaîne JSON est impossible. Veillez à fournir une chaîne JSON valide.",
     "err_devnet_chain_setting_unknown_keys": "Le paramètre de chaîne devnet contient des clés non reconnues.",
-    "err_devnet_chain_setting_negative_multiplier": "Valeur de multiplicateur invalide dans le paramètre de chaîne devnet. Elle ne peut pas être négative.",
     "err_devnet_chain_setting_too_large": "Chaîne JSON invalide pour devnet_chain_setting. Elle dépasse la taille maximale.",
     "err_devnet_chain_setting_invalid_network_name": "network_name invalide dans le paramètre de chaîne devnet. Il doit s'agir d'une chaîne non vide.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 4 octets hexadécimaux.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 4 octets hexadécimaux.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 32 octets hexadécimaux.",
     "err_devnet_chain_setting_invalid_number": "Valeur numérique invalide dans le paramètre de chaîne devnet.",
-    "err_devnet_chain_setting_positive_number": "Les valeurs numériques du paramètre de chaîne devnet doivent être positives."
+    "err_devnet_chain_setting_positive_number": "Les valeurs numériques du paramètre de chaîne devnet doivent être positives.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 4 octets hexadécimaux.",
+      "invalid_exit_fork_version": "exit_fork_version invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 4 octets hexadécimaux.",
+      "invalid_genesis_validator_root": "genesis_validator_root invalide dans le paramètre de chaîne devnet. Il doit comporter exactement 32 octets hexadécimaux."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "Le paramètre de chaîne ne contient pas de valeur GENESIS_VALIDATORS_ROOT. Cette valeur est nécessaire pour créer la transaction de sortie."

--- a/ethstaker_deposit/intl/id/utils/validation.json
+++ b/ethstaker_deposit/intl/id/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Pengaturan chain devnet menggunakan genesis fork version yang sudah dikenal dari jaringan yang ada.",
     "err_devnet_chain_setting_invalid_json": "String JSON untuk devnet_chain_setting tidak valid. String tersebut tidak dapat didekodekan. Pastikan Anda memberikan string JSON yang valid.",
     "err_devnet_chain_setting_unknown_keys": "Pengaturan chain devnet berisi kunci yang tidak dikenali.",
-    "err_devnet_chain_setting_negative_multiplier": "Nilai multiplier dalam pengaturan chain devnet tidak valid. Nilainya tidak boleh negatif.",
     "err_devnet_chain_setting_too_large": "String JSON untuk devnet_chain_setting tidak valid. Ukurannya melebihi batas maksimum.",
     "err_devnet_chain_setting_invalid_network_name": "network_name dalam pengaturan chain devnet tidak valid. Nilainya harus berupa string yang tidak kosong.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 4 byte dalam format heksadesimal.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 4 byte dalam format heksadesimal.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 32 byte dalam format heksadesimal.",
     "err_devnet_chain_setting_invalid_number": "Nilai numerik dalam pengaturan chain devnet tidak valid.",
-    "err_devnet_chain_setting_positive_number": "Nilai numerik dalam pengaturan chain devnet harus positif."
+    "err_devnet_chain_setting_positive_number": "Nilai numerik dalam pengaturan chain devnet harus positif.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 4 byte dalam format heksadesimal.",
+      "invalid_exit_fork_version": "exit_fork_version dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 4 byte dalam format heksadesimal.",
+      "invalid_genesis_validator_root": "genesis_validator_root dalam pengaturan chain devnet tidak valid. Nilainya harus tepat 32 byte dalam format heksadesimal."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "Pengaturan rantai tidak memiliki nilai GENESIS_VALIDATORS_ROOT. Nilai tersebut diperlukan untuk membuat transaksi keluar."

--- a/ethstaker_deposit/intl/it/utils/validation.json
+++ b/ethstaker_deposit/intl/it/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "L'impostazione devnet della catena usa una genesis fork version già nota di una rete esistente.",
     "err_devnet_chain_setting_invalid_json": "Stringa JSON non valida per devnet_chain_setting. Non è stato possibile decodificare la stringa JSON. Assicurati di fornire una stringa JSON valida.",
     "err_devnet_chain_setting_unknown_keys": "L'impostazione devnet della catena contiene chiavi non riconosciute.",
-    "err_devnet_chain_setting_negative_multiplier": "Valore del moltiplicatore non valido nell'impostazione devnet della catena. Non può essere negativo.",
     "err_devnet_chain_setting_too_large": "Stringa JSON non valida per devnet_chain_setting. Supera la dimensione massima.",
     "err_devnet_chain_setting_invalid_network_name": "network_name non valido nell'impostazione devnet della catena. Deve essere una stringa non vuota.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 4 byte esadecimali.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 4 byte esadecimali.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 32 byte esadecimali.",
     "err_devnet_chain_setting_invalid_number": "Valore numerico non valido nell'impostazione devnet della catena.",
-    "err_devnet_chain_setting_positive_number": "I valori numerici nell'impostazione devnet della catena devono essere positivi."
+    "err_devnet_chain_setting_positive_number": "I valori numerici nell'impostazione devnet della catena devono essere positivi.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 4 byte esadecimali.",
+      "invalid_exit_fork_version": "exit_fork_version non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 4 byte esadecimali.",
+      "invalid_genesis_validator_root": "genesis_validator_root non valido nell'impostazione devnet della catena. Deve essere costituito esattamente da 32 byte esadecimali."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "L'impostazione della catena non contiene un valore GENESIS_VALIDATORS_ROOT. Questo valore è necessario per creare la transazione di uscita."

--- a/ethstaker_deposit/intl/ja/utils/validation.json
+++ b/ethstaker_deposit/intl/ja/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "devnet chain setting で既存ネットワークの既知の genesis fork version が使用されています。",
     "err_devnet_chain_setting_invalid_json": "devnet_chain_setting の JSON 文字列が無効です。JSON 文字列をデコードできませんでした。有効な JSON 文字列を渡していることを確認してください。",
     "err_devnet_chain_setting_unknown_keys": "devnet chain setting に認識されないキーが含まれています。",
-    "err_devnet_chain_setting_negative_multiplier": "devnet chain setting の乗数が無効です。負の値にすることはできません。",
     "err_devnet_chain_setting_too_large": "devnet_chain_setting の JSON 文字列が無効です。最大サイズを超えています。",
     "err_devnet_chain_setting_invalid_network_name": "devnet chain setting の network_name が無効です。空でない文字列である必要があります。",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "devnet chain setting の genesis_fork_version が無効です。正確に 4 バイトの 16 進数である必要があります。",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "devnet chain setting の exit_fork_version が無効です。正確に 4 バイトの 16 進数である必要があります。",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "devnet chain setting の genesis_validator_root が無効です。正確に 32 バイトの 16 進数である必要があります。",
     "err_devnet_chain_setting_invalid_number": "devnet chain setting の数値が無効です。",
-    "err_devnet_chain_setting_positive_number": "devnet chain setting の数値は正である必要があります。"
+    "err_devnet_chain_setting_positive_number": "devnet chain setting の数値は正である必要があります。",
+    "dynamic": {
+      "invalid_genesis_fork_version": "devnet chain setting の genesis_fork_version が無効です。正確に 4 バイトの 16 進数である必要があります。",
+      "invalid_exit_fork_version": "devnet chain setting の exit_fork_version が無効です。正確に 4 バイトの 16 進数である必要があります。",
+      "invalid_genesis_validator_root": "devnet chain setting の genesis_validator_root が無効です。正確に 32 バイトの 16 進数である必要があります。"
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "チェーン設定に GENESIS_VALIDATORS_ROOT の値がありません。退出トランザクションの作成にはこの値が必要です。"

--- a/ethstaker_deposit/intl/ko/utils/validation.json
+++ b/ethstaker_deposit/intl/ko/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "devnet 체인 설정이 기존 네트워크의 알려진 genesis fork version을 사용하고 있습니다.",
     "err_devnet_chain_setting_invalid_json": "devnet_chain_setting의 JSON 문자열이 유효하지 않습니다. JSON 문자열을 디코딩할 수 없습니다. 유효한 JSON 문자열을 전달했는지 확인하세요.",
     "err_devnet_chain_setting_unknown_keys": "devnet 체인 설정에 인식할 수 없는 키가 포함되어 있습니다.",
-    "err_devnet_chain_setting_negative_multiplier": "devnet 체인 설정의 multiplier 값이 유효하지 않습니다. 음수일 수 없습니다.",
     "err_devnet_chain_setting_too_large": "devnet_chain_setting의 JSON 문자열이 유효하지 않습니다. 최대 크기를 초과합니다.",
     "err_devnet_chain_setting_invalid_network_name": "devnet 체인 설정의 network_name이 유효하지 않습니다. 비어 있지 않은 문자열이어야 합니다.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "devnet 체인 설정의 genesis_fork_version이 유효하지 않습니다. 정확히 4바이트의 16진수여야 합니다.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "devnet 체인 설정의 exit_fork_version이 유효하지 않습니다. 정확히 4바이트의 16진수여야 합니다.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "devnet 체인 설정의 genesis_validator_root가 유효하지 않습니다. 정확히 32바이트의 16진수여야 합니다.",
     "err_devnet_chain_setting_invalid_number": "devnet 체인 설정의 숫자 값이 유효하지 않습니다.",
-    "err_devnet_chain_setting_positive_number": "devnet 체인 설정의 숫자 값은 양수여야 합니다."
+    "err_devnet_chain_setting_positive_number": "devnet 체인 설정의 숫자 값은 양수여야 합니다.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "devnet 체인 설정의 genesis_fork_version이 유효하지 않습니다. 정확히 4바이트의 16진수여야 합니다.",
+      "invalid_exit_fork_version": "devnet 체인 설정의 exit_fork_version이 유효하지 않습니다. 정확히 4바이트의 16진수여야 합니다.",
+      "invalid_genesis_validator_root": "devnet 체인 설정의 genesis_validator_root가 유효하지 않습니다. 정확히 32바이트의 16진수여야 합니다."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "체인 설정에 GENESIS_VALIDATORS_ROOT 값이 없습니다. 종료 트랜잭션을 생성하려면 이 값이 필요합니다."

--- a/ethstaker_deposit/intl/pt-BR/utils/validation.json
+++ b/ethstaker_deposit/intl/pt-BR/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "A configuração de cadeia devnet usa uma versão de fork de gênese conhecida de uma rede existente.",
     "err_devnet_chain_setting_invalid_json": "String JSON inválida para devnet_chain_setting. Não foi possível decodificar a string JSON. Certifique-se de fornecer uma string JSON válida.",
     "err_devnet_chain_setting_unknown_keys": "A configuração de cadeia devnet contém chaves não reconhecidas.",
-    "err_devnet_chain_setting_negative_multiplier": "Valor de multiplicador inválido na configuração de cadeia devnet. Ele não pode ser negativo.",
     "err_devnet_chain_setting_too_large": "String JSON inválida para devnet_chain_setting. Ela excede o tamanho máximo.",
     "err_devnet_chain_setting_invalid_network_name": "network_name inválido na configuração da cadeia devnet. Deve ser uma string não vazia.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version inválido na configuração da cadeia devnet. Deve ter exatamente 4 bytes em formato hexadecimal.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version inválido na configuração da cadeia devnet. Deve ter exatamente 4 bytes em formato hexadecimal.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root inválido na configuração da cadeia devnet. Deve ter exatamente 32 bytes em formato hexadecimal.",
     "err_devnet_chain_setting_invalid_number": "Valor numérico inválido na configuração da cadeia devnet.",
-    "err_devnet_chain_setting_positive_number": "Os valores numéricos na configuração da cadeia devnet devem ser positivos."
+    "err_devnet_chain_setting_positive_number": "Os valores numéricos na configuração da cadeia devnet devem ser positivos.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version inválido na configuração da cadeia devnet. Deve ter exatamente 4 bytes em formato hexadecimal.",
+      "invalid_exit_fork_version": "exit_fork_version inválido na configuração da cadeia devnet. Deve ter exatamente 4 bytes em formato hexadecimal.",
+      "invalid_genesis_validator_root": "genesis_validator_root inválido na configuração da cadeia devnet. Deve ter exatamente 32 bytes em formato hexadecimal."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "A configuração da cadeia não contém um valor para GENESIS_VALIDATORS_ROOT. Esse valor é necessário para criar a transação de saída."

--- a/ethstaker_deposit/intl/ro/utils/validation.json
+++ b/ethstaker_deposit/intl/ro/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Setarea de lanț devnet folosește o versiune cunoscută de genesis fork de la o rețea existentă.",
     "err_devnet_chain_setting_invalid_json": "Șir JSON invalid pentru devnet_chain_setting. Decodificarea șirului JSON nu a fost posibilă. Asigură-te că transmiți un șir JSON valid.",
     "err_devnet_chain_setting_unknown_keys": "Setarea de lanț devnet conține chei nerecunoscute.",
-    "err_devnet_chain_setting_negative_multiplier": "Valoare invalidă a multiplicatorului în setarea de lanț devnet. Nu poate fi negativă.",
     "err_devnet_chain_setting_too_large": "Șir JSON invalid pentru devnet_chain_setting. Depășește dimensiunea maximă.",
     "err_devnet_chain_setting_invalid_network_name": "network_name invalid în setarea lanțului devnet. Trebuie să fie un șir nevid.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "genesis_fork_version invalid în setarea lanțului devnet. Trebuie să aibă exact 4 octeți în format hexazecimal.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "exit_fork_version invalid în setarea lanțului devnet. Trebuie să aibă exact 4 octeți în format hexazecimal.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "genesis_validator_root invalid în setarea lanțului devnet. Trebuie să aibă exact 32 de octeți în format hexazecimal.",
     "err_devnet_chain_setting_invalid_number": "Valoare numerică invalidă în setarea lanțului devnet.",
-    "err_devnet_chain_setting_positive_number": "Valorile numerice din setarea lanțului devnet trebuie să fie pozitive."
+    "err_devnet_chain_setting_positive_number": "Valorile numerice din setarea lanțului devnet trebuie să fie pozitive.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "genesis_fork_version invalid în setarea lanțului devnet. Trebuie să aibă exact 4 octeți în format hexazecimal.",
+      "invalid_exit_fork_version": "exit_fork_version invalid în setarea lanțului devnet. Trebuie să aibă exact 4 octeți în format hexazecimal.",
+      "invalid_genesis_validator_root": "genesis_validator_root invalid în setarea lanțului devnet. Trebuie să aibă exact 32 de octeți în format hexazecimal."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "Setarea lanțului nu conține o valoare GENESIS_VALIDATORS_ROOT. Această valoare este necesară pentru a crea tranzacția de ieșire."

--- a/ethstaker_deposit/intl/tr/utils/validation.json
+++ b/ethstaker_deposit/intl/tr/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "Devnet zincir ayarı, mevcut bir ağdan bilinen bir genesis fork sürümünü kullanıyor.",
     "err_devnet_chain_setting_invalid_json": "devnet_chain_setting için geçersiz JSON dizesi. JSON dizesinin kodu çözülemedi. Geçerli bir JSON dizesi sağladığınızdan emin olun.",
     "err_devnet_chain_setting_unknown_keys": "Devnet zincir ayarı tanınmayan anahtarlar içeriyor.",
-    "err_devnet_chain_setting_negative_multiplier": "Devnet zincir ayarında geçersiz çarpan değeri. Negatif olamaz.",
     "err_devnet_chain_setting_too_large": "devnet_chain_setting için geçersiz JSON dizesi. Maksimum boyutu aşıyor.",
     "err_devnet_chain_setting_invalid_network_name": "Devnet zincir ayarında geçersiz network_name. Boş olmayan bir dize olmalıdır.",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "Devnet zincir ayarında geçersiz genesis_fork_version. Tam olarak 4 bayt onaltılık biçimde olmalıdır.",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "Devnet zincir ayarında geçersiz exit_fork_version. Tam olarak 4 bayt onaltılık biçimde olmalıdır.",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "Devnet zincir ayarında geçersiz genesis_validator_root. Tam olarak 32 bayt onaltılık biçimde olmalıdır.",
     "err_devnet_chain_setting_invalid_number": "Devnet zincir ayarında geçersiz sayısal değer.",
-    "err_devnet_chain_setting_positive_number": "Devnet zincir ayarındaki sayısal değerler pozitif olmalıdır."
+    "err_devnet_chain_setting_positive_number": "Devnet zincir ayarındaki sayısal değerler pozitif olmalıdır.",
+    "dynamic": {
+      "invalid_genesis_fork_version": "Devnet zincir ayarında geçersiz genesis_fork_version. Tam olarak 4 bayt onaltılık biçimde olmalıdır.",
+      "invalid_exit_fork_version": "Devnet zincir ayarında geçersiz exit_fork_version. Tam olarak 4 bayt onaltılık biçimde olmalıdır.",
+      "invalid_genesis_validator_root": "Devnet zincir ayarında geçersiz genesis_validator_root. Tam olarak 32 bayt onaltılık biçimde olmalıdır."
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "Zincir ayarında GENESIS_VALIDATORS_ROOT değeri eksik. Bu değer, çıkış işlemini oluşturmak için gereklidir."

--- a/ethstaker_deposit/intl/zh-CN/utils/validation.json
+++ b/ethstaker_deposit/intl/zh-CN/utils/validation.json
@@ -57,14 +57,15 @@
     "err_devnet_known_genesis_fork_version": "devnet 链设置使用了现有网络中的已知 genesis fork version。",
     "err_devnet_chain_setting_invalid_json": "devnet_chain_setting 的 JSON 字符串无效。无法解析 JSON 字符串。请确保传入有效的 JSON 字符串。",
     "err_devnet_chain_setting_unknown_keys": "devnet 链设置包含无法识别的键。",
-    "err_devnet_chain_setting_negative_multiplier": "devnet 链设置中的 multiplier 值无效，不能为负数。",
     "err_devnet_chain_setting_too_large": "devnet_chain_setting 的 JSON 字符串无效。它超过了最大大小。",
     "err_devnet_chain_setting_invalid_network_name": "devnet 链设置中的 network_name 无效。它必须是非空字符串。",
-    "err_devnet_chain_setting_invalid_genesis_fork_version": "devnet 链设置中的 genesis_fork_version 无效。它必须正好是 4 字节的十六进制值。",
-    "err_devnet_chain_setting_invalid_exit_fork_version": "devnet 链设置中的 exit_fork_version 无效。它必须正好是 4 字节的十六进制值。",
-    "err_devnet_chain_setting_invalid_genesis_validator_root": "devnet 链设置中的 genesis_validator_root 无效。它必须正好是 32 字节的十六进制值。",
     "err_devnet_chain_setting_invalid_number": "devnet 链设置中的数值无效。",
-    "err_devnet_chain_setting_positive_number": "devnet 链设置中的数值必须为正数。"
+    "err_devnet_chain_setting_positive_number": "devnet 链设置中的数值必须为正数。",
+    "dynamic": {
+      "invalid_genesis_fork_version": "devnet 链设置中的 genesis_fork_version 无效。它必须正好是 4 字节的十六进制值。",
+      "invalid_exit_fork_version": "devnet 链设置中的 exit_fork_version 无效。它必须正好是 4 字节的十六进制值。",
+      "invalid_genesis_validator_root": "devnet 链设置中的 genesis_validator_root 无效。它必须正好是 32 字节的十六进制值。"
+    }
   },
   "validate_genesis_validators_root": {
     "missing_genesis_validators_root": "链设置缺少 GENESIS_VALIDATORS_ROOT 值。创建退出交易需要此值。"

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -544,7 +544,7 @@ def validate_devnet_chain_setting_json(json_value: str) -> bool:
 
         genesis_fork_version = _decode_fixed_hex(
             devnet_chain_setting_dict['genesis_fork_version'], 4,
-            'err_devnet_chain_setting_invalid_genesis_fork_version',
+            'invalid_genesis_fork_version',
         )
         if genesis_fork_version in ALL_FORK_VERSIONS:
             known_network = ALL_FORK_VERSIONS[genesis_fork_version]
@@ -552,13 +552,13 @@ def validate_devnet_chain_setting_json(json_value: str) -> bool:
 
         _decode_fixed_hex(
             devnet_chain_setting_dict['exit_fork_version'], 4,
-            'err_devnet_chain_setting_invalid_exit_fork_version',
+            'invalid_exit_fork_version',
         )
 
         if 'genesis_validator_root' in devnet_chain_setting_dict:
             _decode_fixed_hex(
                 devnet_chain_setting_dict['genesis_validator_root'], 32,
-                'err_devnet_chain_setting_invalid_genesis_validator_root',
+                'invalid_genesis_validator_root',
             )
 
         if 'multiplier' in devnet_chain_setting_dict:
@@ -580,13 +580,19 @@ def validate_devnet_chain_setting_json(json_value: str) -> bool:
 
 def _decode_fixed_hex(value: Any, size: int, message_key: str) -> bytes:
     if not isinstance(value, str):
-        raise ValidationError(load_text([message_key], func='validate_devnet_chain_setting_json') + '\n')
+        raise ValidationError(
+            load_text(['dynamic', message_key], func='validate_devnet_chain_setting_json') + '\n'
+        )
     try:
         decoded = decode_hex(value)
     except (TypeError, ValueError):
-        raise ValidationError(load_text([message_key], func='validate_devnet_chain_setting_json') + '\n')
+        raise ValidationError(
+            load_text(['dynamic', message_key], func='validate_devnet_chain_setting_json') + '\n'
+        )
     if len(decoded) != size:
-        raise ValidationError(load_text([message_key], func='validate_devnet_chain_setting_json') + '\n')
+        raise ValidationError(
+            load_text(['dynamic', message_key], func='validate_devnet_chain_setting_json') + '\n'
+        )
     return decoded
 
 

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -72,9 +72,9 @@ def is_intl_fallback(source_file: Path, node: ast.Call) -> bool:
     )
 
 
-def translation_references(root: Path) -> tuple[dict[Path, set[str]], list[str]]:
+def translation_references(root: Path) -> tuple[dict[Path, set[str]], dict[Path, set[str]]]:
     references: dict[Path, set[str]] = {}
-    warnings: list[str] = []
+    dynamic_prefixes: dict[Path, set[str]] = {}
     for source_file in sorted(root.rglob("*.py")):
         tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
         assigned = assigned_literals(tree)
@@ -97,8 +97,28 @@ def translation_references(root: Path) -> tuple[dict[Path, set[str]], list[str]]
             if func is None and isinstance(keywords.get("func"), ast.Name):
                 func = assigned_strings_map.get(keywords["func"].id)
             if params is None or ("func" in keywords and func is None):
-                source_name = source_file.relative_to(root.parent).as_posix()
-                warnings.append(f"{source_name}:{node.lineno}: dynamic load_text reference")
+                dynamic_func = literal_string(keywords.get("func")) or source_file.stem
+                if dynamic_func == source_file.stem:
+                    for parent, name in function_names.items():
+                        if parent.lineno <= node.lineno <= (getattr(parent, "end_lineno", parent.lineno)):
+                            dynamic_func = name
+                            break
+                file_path = literal_string(keywords.get("file_path"))
+                if file_path is None:
+                    relative = source_file.relative_to(root).with_suffix(".json")
+                else:
+                    relative_path = Path(file_path)
+                    relative = relative_path.relative_to(root) if relative_path.is_absolute() else relative_path
+                    if relative.parts and relative.parts[0] == "ethstaker_deposit":
+                        relative = Path(*relative.parts[1:])
+                    if relative.suffix != ".json":
+                        relative = relative.with_suffix(".json")
+                dynamic_path = ""
+                if node.args and isinstance(node.args[0], ast.List):
+                    literal_prefix = literal_string(node.args[0].elts[0]) if node.args[0].elts else None
+                    if literal_prefix is not None:
+                        dynamic_path = literal_prefix + "."
+                dynamic_prefixes.setdefault(relative, set()).add(f"{dynamic_func}.{dynamic_path}")
                 continue
             if func is None:
                 func = source_file.stem
@@ -117,13 +137,13 @@ def translation_references(root: Path) -> tuple[dict[Path, set[str]], list[str]]
                 if relative.suffix != ".json":
                     relative = relative.with_suffix(".json")
             references.setdefault(relative, set()).add(".".join([func, *params]))
-    return references, warnings
+    return references, dynamic_prefixes
 
 
 def main() -> int:
     errors: list[str] = []
     fallback_count = 0
-    references, warnings = translation_references(ROOT.parent)
+    references, dynamic_prefixes = translation_references(ROOT.parent)
     english_files = sorted((ROOT / "en").rglob("*.json"))
     languages = sorted(p.name for p in ROOT.iterdir() if p.is_dir() and p.name != "en" and p.name != "__pycache__")
     for english_file in english_files:
@@ -131,6 +151,8 @@ def main() -> int:
         relative = english_file.relative_to(ROOT / "en")
         referenced = references.get(relative, set())
         for key in sorted(set(source) - referenced):
+            if any(key.startswith(prefix) for prefix in dynamic_prefixes.get(relative, set())):
+                continue
             errors.append(f"orphaned key {relative}:{key}")
     for language in languages:
         for english_file in english_files:
@@ -151,11 +173,7 @@ def main() -> int:
                     fallback_count += 1
     if errors:
         print("\n".join(errors))
-        if warnings:
-            print("\n".join(f"warning: {warning}" for warning in warnings))
         return 1
-    if warnings:
-        print("\n".join(f"warning: {warning}" for warning in warnings))
     print(
         f"Checked {len(languages)} locales against {len(english_files)} English files; "
         f"{fallback_count} English fallbacks remain."

--- a/tests/test_check_translations.py
+++ b/tests/test_check_translations.py
@@ -19,10 +19,10 @@ def test_translation_references_resolves_literal_calls(tmp_path: Path) -> None:
         encoding='utf-8',
     )
 
-    references, warnings = translation_references(package)
+    references, dynamic_prefixes = translation_references(package)
 
     assert references == {Path('feature.json'): {'render.message.prompt'}}
-    assert warnings == []
+    assert dynamic_prefixes == {}
 
 
 def test_translation_references_resolves_explicit_file_and_function(tmp_path: Path) -> None:
@@ -35,13 +35,13 @@ def test_translation_references_resolves_explicit_file_and_function(tmp_path: Pa
         encoding='utf-8',
     )
 
-    references, warnings = translation_references(package)
+    references, dynamic_prefixes = translation_references(package)
 
     assert references == {Path('shared.json'): {'shared.message'}}
-    assert warnings == []
+    assert dynamic_prefixes == {}
 
 
-def test_translation_references_warns_for_dynamic_calls(tmp_path: Path) -> None:
+def test_translation_references_ignores_dynamic_calls(tmp_path: Path) -> None:
     package = tmp_path / 'ethstaker_deposit'
     package.mkdir()
     source = package / 'feature.py'
@@ -52,11 +52,10 @@ def test_translation_references_warns_for_dynamic_calls(tmp_path: Path) -> None:
     )
     source.write_text(source_text, encoding='utf-8')
 
-    references, warnings = translation_references(package)
+    references, dynamic_prefixes = translation_references(package)
 
     assert references == {}
-    load_text_line = source_text.splitlines().index('load_text(params)') + 1
-    assert warnings == [f'ethstaker_deposit/feature.py:{load_text_line}: dynamic load_text reference']
+    assert dynamic_prefixes == {Path('feature.json'): {'feature.'}}
 
 
 def test_translation_references_ignores_intl_fallback(tmp_path: Path) -> None:
@@ -70,15 +69,36 @@ def test_translation_references_ignores_intl_fallback(tmp_path: Path) -> None:
         encoding='utf-8',
     )
 
-    references, warnings = translation_references(package)
+    references, dynamic_prefixes = translation_references(package)
 
     assert references == {}
-    assert warnings == []
+    assert dynamic_prefixes == {}
+
+
+def test_translation_references_marks_dynamic_validation_file(tmp_path: Path) -> None:
+    package = tmp_path / 'ethstaker_deposit'
+    utils = package / 'utils'
+    utils.mkdir(parents=True)
+    source = utils / 'validation.py'
+    source.write_text(
+        'from ethstaker_deposit.utils.intl import load_text\n'
+        'def _decode_fixed_hex(message_key):\n'
+        "    return load_text(['dynamic', message_key], func='validate_devnet_chain_setting_json')\n",
+        encoding='utf-8',
+    )
+
+    references, dynamic_prefixes = translation_references(package)
+
+    assert references == {}
+    assert dynamic_prefixes == {Path('utils/validation.json'): {'validate_devnet_chain_setting_json.dynamic.'}}
 
 
 def test_repository_has_no_orphaned_english_keys() -> None:
-    references, warnings = translation_references(ROOT.parent)
-    assert warnings == []
+    references, dynamic_prefixes = translation_references(ROOT.parent)
     for english_file in (ROOT / 'en').rglob('*.json'):
         relative = english_file.relative_to(ROOT / 'en')
-        assert set(leaves(json.loads(english_file.read_text(encoding='utf-8')))) <= references.get(relative, set())
+        missing = set(leaves(json.loads(english_file.read_text(encoding='utf-8')))) - references.get(relative, set())
+        assert not {
+            key for key in missing
+            if not any(key.startswith(prefix) for prefix in dynamic_prefixes.get(relative, set()))
+        }


### PR DESCRIPTION
**What I did**

- Teach the test to ignore dynamically loaded keys by namespace. They are moved into their own nested `dynamic` namespace
- Remove one remaining orphan string
