### PR TITLE
Add some end to end usage docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,12 +8,18 @@
 
 - [New Mnemonic](new_mnemonic.md)
 - [Existing Mnemonic](existing_mnemonic.md)
+- [Generate Mnemonic](generate_mnemonic.md)
 - [Generate BLS to Execution Change](generate_bls_to_execution_change.md)
 - [Generate BLS to Execution Change Keystore](generate_bls_to_execution_change_keystore.md)
 - [Exit Transaction Keystore](exit_transaction_keystore.md)
 - [Exit Transaction Mnemonic](exit_transaction_mnemonic.md)
 - [Partial Deposit](partial_deposit.md)
 - [Test Keystore](test_keystore.md)
+
+# End to End Usage
+
+- [Fully Automatic Key Generation](scripted_keygen.md)
+- [Mnemonic Verification](verify_mnemonic.md)
 
 # File formats
 

--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -44,4 +44,6 @@ A successful call to this command will result in one or many [keystore files](ke
 
 ## Note
 
+The withdrawal address **must** be under your control, either an EOA or a smart contract wallet. Do **not** use an exchange wallet. If you do not control the withdrawal address, funds **cannot** be recovered.
+
 For non-compounding validators, a custom deposit amount requires an existing keystore file and the **[partial-deposit](partial_deposit.md)** command. Compounding validators (0x02 withdrawal credentials) can set a custom deposit amount directly using `--amount`.

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -38,6 +38,8 @@ A successful call to this command will result in one or many [keystore files](ke
 
 ## Note
 
+The withdrawal address **must** be under your control, either an EOA or a smart contract wallet. Do **not** use an exchange wallet. If you do not control the withdrawal address, funds **cannot** be recovered.
+
 The newly generated mnemonic **must** be written down, on a piece of paper or transferred to steel. The application will attempt to clear the clipboard when this command finishes. If the mnemonic is lost and the validator does not have a withdrawal address, funds **cannot** be recovered.
 
 For non-compounding validators, a custom deposit amount requires an existing keystore file and the **[partial-deposit](partial_deposit.md)** command. Compounding validators (0x02 withdrawal credentials) can set a custom deposit amount directly using `--amount`.

--- a/docs/src/scripted_keygen.md
+++ b/docs/src/scripted_keygen.md
@@ -1,0 +1,31 @@
+# Fully Automatic Key Generation
+
+{{#include ./snippet/warning_message.md}}
+
+## Description
+
+ethstaker-deposit-cli supports generating keys via script, and no prompts will be shown. This is achieved by using the **[generate-mnemonic](generate_mnemonic.md)** command followed by the **[existing-mnemonic](existing_mnemonic.md)** command. Of necessity, the keystore password and mnemonic will be on command line with this workflow. Ensure these secrets are properly safeguarded.
+
+Parameters are positional: `--language`, `--non-interactive`, `--ignore_connectivity` all come before the command.
+
+## Example Usage
+
+```sh
+./deposit --non_interactive --ignore_connectivity --language english generate-mnemonic --mnemonic_language english --output_file ./test-mnemonic.txt
+```
+
+This creates a file `./test-mnemonic.txt`, which is used in the following step. Fill in the `<>` placeholders. If creating validators for the first time with this mnemonic, choose a start index of `0`.
+
+```sh
+./deposit --non_interactive --ignore_connectivity --language english existing-mnemonic --compounding --amount <deposit-amount> --withdrawal_address <your-withdrawal-address> --chain mainnet --keystore_password <your-password> --num_validators <num-validators-to-create> --validator_start_index <index-to-start> --mnemonic "$(cat ./test-mnemonic.txt)"
+```
+
+This creates the desired number of validator keys as `keystore-m_12381_3600_<index>_0_0-<timestamp>.json` and a matching `deposit_data-<timestamp>.json` in the `./validator_keys` directory. Add a `--folder` parameter to adjust the location of the output files.
+
+## Note
+
+The withdrawal address **must** be under your control, either an EOA or a smart contract wallet. Do **not** use an exchange wallet. If you do not control the withdrawal address, funds **cannot** be recovered.
+
+The newly generated mnemonic **must** be written down, on a piece of paper or transferred to steel. If the mnemonic is lost and the validator does not have a withdrawal address, funds **cannot** be recovered.
+
+For non-compounding validators, a custom deposit amount requires an existing keystore file and the **[partial-deposit](partial_deposit.md)** command. Compounding validators (0x02 withdrawal credentials) can set a custom deposit amount directly using `--amount`.

--- a/docs/src/scripted_keygen.md
+++ b/docs/src/scripted_keygen.md
@@ -6,7 +6,7 @@
 
 ethstaker-deposit-cli supports generating keys via script, and no prompts will be shown. This is achieved by using the **[generate-mnemonic](generate_mnemonic.md)** command followed by the **[existing-mnemonic](existing_mnemonic.md)** command. Of necessity, the keystore password and mnemonic will be on command line with this workflow. Ensure these secrets are properly safeguarded.
 
-Parameters are positional: `--language`, `--non-interactive`, `--ignore_connectivity` all come before the command.
+Parameters are positional: `--language`, `--non_interactive`, `--ignore_connectivity` all come before the command.
 
 ## Example Usage
 

--- a/docs/src/verify_mnemonic.md
+++ b/docs/src/verify_mnemonic.md
@@ -1,0 +1,29 @@
+# Verify Mnemonic
+
+{{#include ./snippet/warning_message.md}}
+
+## Description
+
+To verify a mnemonic you recorded, you can use the **[existing-mnemonic](existing_mnemonic.md)** command.
+
+## Example Usage
+
+Assume you have generated keys from index 0 with the **[new-mnemonic](new_mnemonic.md)** command, and these are in `./validator_keys`.
+
+Generate one key, from the same index, using the  **[existing-mnemonic](existing_mnemonic.md)** command, and write the generated files into a separate directory. Then compare the `pubkey`. If it matches, you correctly recorded the mnemonic.
+
+```sh
+mkdir -p ./verification_key
+./deposit --language english --non_interactive existing-mnemonic --withdrawal_address 0x0000000000000000000000000000000000000000 --chain mainnet --keystore_password WeWontUseThis --compounding --amount 2048 --num_validators 1 --validator_start_index 0 --folder ./verification_key
+```
+
+This creates one validator key as `keystore-m_12381_3600_0_0_0-<timestamp>.json` in the `./verification_key` directory. The command will prompt you for the mnemonic. The `deposit_data` file won't be used, so we can safely specify a dummy withdrawal address and amount.
+
+Either just look at the two generated files, or use `jq` (install it first) to generate the pubkey from each:
+
+```sh
+jq .pubkey ./validator_keys/keystore-m_12381_3600_0_0_0-<timestamp>.json
+jq .pubkey ./verification_key/keystore-m_12381_3600_0_0_0-<timestamp>.json
+```
+
+If this pubkey matches, the same mnemonic was used both times.


### PR DESCRIPTION
**What I did**

Add documentation for fully automated key generation, and mnemonic verification.

Add a warning about withdrawal address

Include `generate-mnemonic` in the index

Tested with `mdbook serve ./docs --open`

This PR was entirely human-created

**Related issue**
closes #87 
