### PR TITLE
Fix a regression in load_text

### DIFF
--- a/ethstaker_deposit/utils/intl.py
+++ b/ethstaker_deposit/utils/intl.py
@@ -31,13 +31,38 @@ def _get_from_dict(dataDict: dict[str, Any], mapList: Iterable[str]) -> str:
         raise KeyError(f'The provided params ({mapList}) were incomplete.')
 
 
+_ROOT_PACKAGE = os.path.dirname(INTL_CONTENT_PATH)
+
+
+def _resolve_rel_path(caller: Any, file_path: str, auto_detected: bool) -> list[str]:
+    '''
+    Resolve the intl JSON path (relative to INTL_CONTENT_PATH/<lang>) for a load_text call.
+    '''
+    # Auto-detected calls use the caller's module name, which frozen builds preserve even
+    # when the reported file name collapses to a bare basename (for example, deposit.py).
+    module_name = caller.frame.f_globals.get('__name__', '')
+    if auto_detected and module_name.startswith(_ROOT_PACKAGE + '.'):
+        rel_path_list = module_name.split('.')[1:]
+        rel_path_list[-1] += '.json'
+        return rel_path_list
+
+    file_path_list = os.path.normpath(file_path).split(os.path.sep)
+    if _ROOT_PACKAGE in file_path_list:
+        last_occurrence = len(file_path_list) - file_path_list[::-1].index(_ROOT_PACKAGE)
+        return file_path_list[last_occurrence:]
+    return [os.path.basename(file_path)]
+
+
 def load_text(params: list[str], file_path: str = '', func: str = '', lang: str = '') -> str:
     '''
     Determine and return the appropriate internationalisation text for a given set of `params`.
     '''
-    if file_path == '':
+    caller = inspect.stack()[1]
+    auto_detected = file_path == ''
+
+    if auto_detected:
         # Auto-detect file-path based on call stack
-        file_path = inspect.stack()[1].filename
+        file_path = caller.filename
         if file_path[-4:] == '.pyc':
             file_path = file_path[:-4] + '.json'  # replace .pyc with .json
         elif file_path[-3:] == '.py':
@@ -53,17 +78,13 @@ def load_text(params: list[str], file_path: str = '', func: str = '', lang: str 
 
     if func == '':
         # Auto-detect function based on call stack
-        func = inspect.stack()[1].function
+        func = caller.function
 
     if lang == '':
         lang = config.language
 
     # Determine path to json text
-    file_path_list = os.path.normpath(file_path).split(os.path.sep)
-
-    # Find the relative path to the internationalization file from the project directory
-    last_occurrence = len(file_path_list) - file_path_list[::-1].index('ethstaker_deposit')
-    rel_path_list = file_path_list[last_occurrence:]
+    rel_path_list = _resolve_rel_path(caller, file_path, auto_detected)
 
     json_path = resource_path(os.path.join(INTL_CONTENT_PATH, lang, *rel_path_list))
 
@@ -76,7 +97,13 @@ def load_text(params: list[str], file_path: str = '', func: str = '', lang: str 
         # If text not found in lang, try return English version
         if lang == 'en':
             raise KeyError(f'{[func] + params} not in {json_path} file')
-        return load_text(params, file_path, func, 'en')
+        en_path = resource_path(os.path.join(INTL_CONTENT_PATH, 'en', *rel_path_list))
+        try:
+            with open(en_path, encoding='utf-8') as f:
+                text_dict = json.load(f)
+                return _get_from_dict(text_dict, [func] + params)
+        except (KeyError, FileNotFoundError):
+            raise KeyError(f'{[func] + params} not in {en_path} file')
 
 
 def get_first_options(options: Mapping[str, Sequence[str]]) -> list[str]:

--- a/tests/test_utils/test_intl.py
+++ b/tests/test_utils/test_intl.py
@@ -6,6 +6,7 @@ from ethstaker_deposit.utils.constants import (
     MNEMONIC_LANG_OPTIONS,
 )
 from ethstaker_deposit.utils.intl import (
+    _resolve_rel_path,
     fuzzy_reverse_dict_lookup,
     get_first_options,
     load_text,
@@ -31,6 +32,32 @@ def test_load_text_source_path_matches_json_path() -> None:
     json_path = os.path.join('ethstaker_deposit', 'cli', 'new_mnemonic.json')
 
     assert load_text(params, source_path, func, 'en') == load_text(params, json_path, func, 'en')
+
+
+def test_load_text_frozen_basename_uses_module_translation() -> None:
+    assert 'connectivity' in load_text(['connectivity_warning'], 'deposit.py', 'check_connectivity', 'en').lower()
+
+
+class _FakeFrame:
+    f_globals: dict
+
+
+class _FakeCaller:
+    def __init__(self, module_name: str) -> None:
+        frame = _FakeFrame()
+        frame.f_globals = {'__name__': module_name}
+        self.frame = frame
+
+
+@pytest.mark.parametrize(
+    'module_name, expected', [
+        ('ethstaker_deposit.cli.new_mnemonic', ['cli', 'new_mnemonic.json']),
+        ('ethstaker_deposit.utils.intl', ['utils', 'intl.json']),
+        ('ethstaker_deposit.cli.sub.new_mnemonic', ['cli', 'sub', 'new_mnemonic.json']),
+    ]
+)
+def test_resolve_rel_path_auto_detected(module_name: str, expected: list[str]) -> None:
+    assert _resolve_rel_path(_FakeCaller(module_name), file_path='', auto_detected=True) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What I did**

The Python 3.14 work in #592 introduced an issue where the packaged executable would not find its intl files, because the change to Python 3.14 and its build tools reports the package differently as just `deposit.py` instead of `ethstaker_deposit/deposit.py`

The fix code looked for `ethstaker_deposit` and adjusts the lookup accordingly. However I didn't like the hard code.

A second commit no longer hard-codes `ethstaker_deposit`. We have a bit more code, but lose the hard-coded dependency. Please weigh in on pros/cons

Initial fix by GPT 5.6 Luna
Dynamic detection commit by DeepSeek V4 Flash