### PR TITLE
Refactor interactive tests

### DIFF
--- a/tests/test_cli/conftest.py
+++ b/tests/test_cli/conftest.py
@@ -1,0 +1,22 @@
+import os
+import subprocess  # noqa: S404
+import pytest
+
+
+@pytest.fixture(scope='session')
+def deposit_cli_installed() -> None:
+    '''
+    Install the CLI dependencies once per test session, instead of every
+    subprocess-based test running `deposit.sh install` itself.
+    '''
+    run_script_cmd = 'bash deposit.sh' if os.name == 'nt' else './deposit.sh'
+    result = subprocess.run(  # noqa: S602
+        run_script_cmd + ' install',
+        shell=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (
+        f'{run_script_cmd} install failed with code {result.returncode}\n'
+        f'--- stdout ---\n{result.stdout.decode(errors="replace")[-4000:]}\n'
+        f'--- stderr ---\n{result.stderr.decode(errors="replace")[-2000:]}'
+    )

--- a/tests/test_cli/interactive.py
+++ b/tests/test_cli/interactive.py
@@ -1,0 +1,158 @@
+import asyncio
+import os
+import re
+
+ANSI_ESCAPE_PATTERN = re.compile(
+    r'\x1b(?:'
+    r'\[[0-9;?]*[A-Za-z]'              # CSI sequences (cursor movement, colors, ...)
+    r'|\][^\x07]*(?:\x07|\x1b\\)'      # OSC sequences (window title, ...)
+    r'|[@-Z\\-_=>c78]'                 # other two-byte escape sequences (e.g. \x1bc full reset)
+    r')'
+)
+
+DEFAULT_READ_TIMEOUT = 60.0
+DEFAULT_EXPECT_TIMEOUT = 120.0
+DEFAULT_EXIT_TIMEOUT = 300.0
+
+
+class InteractiveProcess:
+    '''
+    Expect-style helper for running the CLI as a subprocess with piped stdin/stdout
+    and simulating user interaction.
+
+    Robustness properties compared to hand-rolled scraping:
+    - every read and the exit wait are bounded by timeouts, so a missing prompt
+      fails fast instead of hanging the whole test suite;
+    - ANSI escape sequences are stripped before matching;
+    - prompts are located by substring instead of exact line prefixes;
+    - stderr is merged into stdout and all observed lines are kept in a
+      transcript that is included in failure messages;
+    - the exit code is asserted to be 0 by `wait()`;
+    - the subprocess is killed if the test fails while it is still running.
+
+    Only one interaction currently exists in the `--non_interactive` flows:
+    the mnemonic retype `click.prompt`. The `click.pause()` calls in the CLI
+    ("press any key", clipboard clearing) are no-ops and print nothing when
+    stdin/stdout are not TTYs (verified against click's implementation), so
+    they require no simulated input here.
+    '''
+
+    def __init__(
+        self,
+        command: str,
+        *,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+        expect_timeout: float = DEFAULT_EXPECT_TIMEOUT,
+        exit_timeout: float = DEFAULT_EXIT_TIMEOUT,
+    ) -> None:
+        self._command = command
+        self._read_timeout = read_timeout
+        self._expect_timeout = expect_timeout
+        self._exit_timeout = exit_timeout
+        self.transcript: list[str] = []
+        self._process: asyncio.subprocess.Process | None = None
+
+    async def __aenter__(self) -> 'InteractiveProcess':
+        env = os.environ.copy()
+        # PYTEST_CURRENT_TEST is deliberately kept in the child environment:
+        # ethstaker_deposit.utils.terminal.clear_terminal() skips clearing under
+        # pytest. Without it, the child would run `clear`/`tput reset`/`reset`
+        # writing ANSI sequences into the pipe we scrape, which the stripping in
+        # readline() defends against but which we should not rely on.
+        self._process = await asyncio.create_subprocess_shell(  # noqa: S602
+            self._command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=env,
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._process is not None and self._process.returncode is None:
+            self._process.kill()
+            await self._process.wait()
+
+    def fail(self, message: str) -> AssertionError:
+        '''
+        Build an AssertionError including the recent subprocess output.
+        '''
+        tail = '\n'.join(self.transcript[-100:])
+        return AssertionError(f'{message}\n--- subprocess output ---\n{tail}')
+
+    async def readline(self) -> str | None:
+        '''
+        Read one line of subprocess output with ANSI escapes stripped.
+        Returns None on EOF.
+        '''
+        if self._process is None:
+            raise RuntimeError('InteractiveProcess was not started')
+        try:
+            raw = await asyncio.wait_for(
+                self._process.stdout.readline(),
+                timeout=self._read_timeout,
+            )
+        except asyncio.TimeoutError as e:
+            raise self.fail(
+                f'Timed out after {self._read_timeout}s waiting for subprocess output'
+            ) from e
+        if not raw:
+            return None
+        line = ANSI_ESCAPE_PATTERN.sub('', raw.decode('utf-8', errors='replace')).rstrip('\r\n')
+        self.transcript.append(line)
+        return line
+
+    async def expect(self, substring: str, timeout: float | None = None) -> str:
+        '''
+        Read lines until one contains `substring`; returns the matching line.
+        Raises if the subprocess exits or the timeout expires first.
+        '''
+        effective_timeout = timeout if timeout is not None else self._expect_timeout
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + effective_timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise self.fail(f'Did not see {substring!r} within {effective_timeout}s')
+            try:
+                line = await self.readline_with_timeout(remaining)
+            except AssertionError as e:
+                # readline() only raises AssertionError on a read timeout.
+                raise self.fail(f'Did not see {substring!r} within {effective_timeout}s') from e
+            if line is None:
+                raise self.fail(
+                    f'Subprocess exited before {substring!r} was seen (exit code {self._process.returncode})'
+                )
+            if substring in line:
+                return line
+
+    async def readline_with_timeout(self, timeout: float) -> str | None:
+        saved_timeout = self._read_timeout
+        self._read_timeout = timeout
+        try:
+            return await self.readline()
+        finally:
+            self._read_timeout = saved_timeout
+
+    async def sendline(self, text: str) -> None:
+        '''
+        Write one line to the subprocess stdin, simulating user input.
+        '''
+        stdin = self._process.stdin
+        stdin.write(text.encode('utf-8') + b'\n')
+        await stdin.drain()
+
+    async def wait(self) -> None:
+        '''
+        Wait for the subprocess to exit and assert a zero exit code.
+        '''
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=self._exit_timeout)
+        except asyncio.TimeoutError as e:
+            self._process.kill()
+            await self._process.wait()
+            raise self.fail(
+                f'Subprocess did not exit within {self._exit_timeout}s'
+            ) from e
+        if self._process.returncode != 0:
+            raise self.fail(f'Subprocess exited with code {self._process.returncode}')

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os
 
@@ -16,6 +15,7 @@ from ethstaker_deposit.utils.constants import (
     DEFAULT_ACTIVATION_AMOUNT,
 )
 from .helpers import clean_key_folder, get_permissions, get_uuid
+from .interactive import InteractiveProcess
 
 
 def test_existing_mnemonic_bls_withdrawal() -> None:
@@ -528,7 +528,7 @@ def test_pbkdf2_new_mnemonic() -> None:
 
 
 @pytest.mark.asyncio
-async def test_script() -> None:
+async def test_script(deposit_cli_installed) -> None:
     my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
     if not os.path.exists(my_folder_path):
         os.mkdir(my_folder_path)
@@ -537,12 +537,6 @@ async def test_script() -> None:
         run_script_cmd = 'bash deposit.sh'
     else:  # Mac or Linux
         run_script_cmd = './deposit.sh'
-
-    install_cmd = run_script_cmd + ' install'
-    proc = await asyncio.create_subprocess_shell(
-        install_cmd,
-    )
-    await proc.wait()
 
     cmd_args = [
         run_script_cmd,
@@ -558,10 +552,8 @@ async def test_script() -> None:
         '--withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
-    proc = await asyncio.create_subprocess_shell(
-        ' '.join(cmd_args),
-    )
-    await proc.wait()
+    async with InteractiveProcess(' '.join(cmd_args)) as process:
+        await process.wait()
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
@@ -577,7 +569,7 @@ async def test_script() -> None:
 
 
 @pytest.mark.asyncio
-async def test_script_abbreviated_mnemonic() -> None:
+async def test_script_abbreviated_mnemonic(deposit_cli_installed) -> None:
     my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
     if not os.path.exists(my_folder_path):
         os.mkdir(my_folder_path)
@@ -586,12 +578,6 @@ async def test_script_abbreviated_mnemonic() -> None:
         run_script_cmd = 'bash deposit.sh'
     else:  # Mac or Linux
         run_script_cmd = './deposit.sh'
-
-    install_cmd = run_script_cmd + ' install'
-    proc = await asyncio.create_subprocess_shell(
-        install_cmd,
-    )
-    await proc.wait()
 
     cmd_args = [
         run_script_cmd,
@@ -607,10 +593,8 @@ async def test_script_abbreviated_mnemonic() -> None:
         '--withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
-    proc = await asyncio.create_subprocess_shell(
-        ' '.join(cmd_args),
-    )
-    await proc.wait()
+    async with InteractiveProcess(' '.join(cmd_args)) as process:
+        await process.wait()
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)

--- a/tests/test_cli/test_exit_transaction_mnemonic.py
+++ b/tests/test_cli/test_exit_transaction_mnemonic.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import pytest
 import json
@@ -9,6 +8,7 @@ from ethstaker_deposit.deposit import cli
 from ethstaker_deposit.utils.constants import DEFAULT_EXIT_TRANSACTION_FOLDER_NAME
 
 from tests.test_cli.helpers import clean_exit_transaction_folder, read_json_file, verify_file_permission
+from tests.test_cli.interactive import InteractiveProcess
 
 
 def test_exit_transaction_mnemonic() -> None:
@@ -57,7 +57,7 @@ def test_exit_transaction_mnemonic() -> None:
 
 
 @pytest.mark.asyncio
-async def test_exit_transaction_mnemonic_multiple() -> None:
+async def test_exit_transaction_mnemonic_multiple(deposit_cli_installed) -> None:
     # Prepare folder
     my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
     clean_exit_transaction_folder(my_folder_path)
@@ -68,12 +68,6 @@ async def test_exit_transaction_mnemonic_multiple() -> None:
         run_script_cmd = 'bash deposit.sh'
     else:  # Mac or Linux
         run_script_cmd = './deposit.sh'
-
-    install_cmd = run_script_cmd + ' install'
-    proc = await asyncio.create_subprocess_shell(
-        install_cmd,
-    )
-    await proc.wait()
 
     cmd_args = [
         run_script_cmd,
@@ -87,12 +81,8 @@ async def test_exit_transaction_mnemonic_multiple() -> None:
         '--validator_indices', '0,1,2,3',
         '--epoch', '1234',
     ]
-    proc = await asyncio.create_subprocess_shell(
-        ' '.join(cmd_args),
-    )
-    await proc.wait()
-
-    assert proc.returncode == 0
+    async with InteractiveProcess(' '.join(cmd_args)) as process:
+        await process.wait()
 
     # Check files
     exit_transaction_folder_path = os.path.join(my_folder_path, DEFAULT_EXIT_TRANSACTION_FOLDER_NAME)

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os
 
@@ -23,6 +22,7 @@ from ethstaker_deposit.utils.constants import (
 )
 from ethstaker_deposit.utils.intl import load_text
 from .helpers import clean_key_folder, get_permissions, get_uuid
+from .interactive import InteractiveProcess
 
 
 @pytest.fixture(autouse=True)
@@ -876,7 +876,7 @@ def test_pbkdf2_new_mnemonic(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_script_bls_withdrawal() -> None:
+async def test_script_bls_withdrawal(deposit_cli_installed) -> None:
     # Prepare folder
     my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
     clean_key_folder(my_folder_path)
@@ -887,12 +887,6 @@ async def test_script_bls_withdrawal() -> None:
         run_script_cmd = 'bash deposit.sh'
     else:  # Mac or Linux
         run_script_cmd = './deposit.sh'
-
-    install_cmd = run_script_cmd + ' install'
-    proc = await asyncio.create_subprocess_shell(
-        install_cmd,
-    )
-    await proc.wait()
 
     cmd_args = [
         run_script_cmd,
@@ -906,39 +900,34 @@ async def test_script_bls_withdrawal() -> None:
         '--withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
-    proc = await asyncio.create_subprocess_shell(
-        ' '.join(cmd_args),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-    )
+
+    mnemonic_json_file = os.path.join(os.getcwd(), 'ethstaker_deposit/../ethstaker_deposit/cli/', 'new_mnemonic.json')
+    msg_mnemonic_presentation = load_text(['msg_mnemonic_presentation'], mnemonic_json_file, 'new_mnemonic')
+    msg_mnemonic_retype_prompt = load_text(['msg_mnemonic_retype_prompt'], mnemonic_json_file, 'new_mnemonic')
+    msg_mnemonic_clipboard_warning = load_text(['msg_mnemonic_clipboard_warning'], mnemonic_json_file, 'new_mnemonic')
 
     seed_phrase = ''
-    encoded_phrase = b''
-    parsing = False
-    mnemonic_json_file = os.path.join(os.getcwd(), 'ethstaker_deposit/../ethstaker_deposit/cli/', 'new_mnemonic.json')
-    msg_mnemonic_clipboard_warning = load_text(['msg_mnemonic_clipboard_warning'], mnemonic_json_file, 'new_mnemonic')
-    async for out in proc.stdout:
-        output = out.decode('utf-8').rstrip()
-        if output.startswith(load_text(['msg_mnemonic_presentation'], mnemonic_json_file, 'new_mnemonic')):
-            parsing = True
-        elif output.startswith(load_text(['msg_mnemonic_retype_prompt'], mnemonic_json_file, 'new_mnemonic')):
-            proc.stdin.write(encoded_phrase)
-            proc.stdin.write(b'\n')
-        elif output.startswith(load_text(['msg_confirm_clipboard_clearing'], mnemonic_json_file, 'new_mnemonic')):
-            proc.stdin.write(b'\n')
-        elif parsing:
+
+    async with InteractiveProcess(' '.join(cmd_args)) as process:
+        await process.expect(msg_mnemonic_presentation)
+
+        # Collect the mnemonic itself, skipping the separator lines and the
+        # clipboard warning printed around it.
+        while True:
+            line = await process.readline()
+            if line is None:
+                raise process.fail('Subprocess exited before asking to retype the mnemonic')
+            if msg_mnemonic_retype_prompt in line:
+                break
             if (
-                not output.startswith('********************')
-                and not output.startswith(msg_mnemonic_clipboard_warning)
+                not line.startswith('********************')
+                and msg_mnemonic_clipboard_warning not in line
             ):
-                seed_phrase += output
-                if len(seed_phrase) > 0:
-                    encoded_phrase = seed_phrase.encode()
-                    parsing = False
+                seed_phrase += line
 
-    assert len(seed_phrase) > 0
-
-    await proc.wait()
+        assert len(seed_phrase.strip()) > 0
+        await process.sendline(seed_phrase.strip())
+        await process.wait()
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
@@ -971,7 +960,7 @@ async def test_script_bls_withdrawal() -> None:
 
 
 @pytest.mark.asyncio
-async def test_script_abbreviated_mnemonic() -> None:
+async def test_script_abbreviated_mnemonic(deposit_cli_installed) -> None:
     # Prepare folder
     my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
     clean_key_folder(my_folder_path)
@@ -982,12 +971,6 @@ async def test_script_abbreviated_mnemonic() -> None:
         run_script_cmd = 'bash deposit.sh'
     else:  # Mac or Linux
         run_script_cmd = './deposit.sh'
-
-    install_cmd = run_script_cmd + ' install'
-    proc = await asyncio.create_subprocess_shell(
-        install_cmd,
-    )
-    await proc.wait()
 
     cmd_args = [
         run_script_cmd,
@@ -1001,40 +984,36 @@ async def test_script_abbreviated_mnemonic() -> None:
         '--withdrawal_address', '""',
         '--folder', my_folder_path,
     ]
-    proc = await asyncio.create_subprocess_shell(
-        ' '.join(cmd_args),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-    )
+
+    mnemonic_json_file = os.path.join(os.getcwd(), 'ethstaker_deposit/../ethstaker_deposit/cli/', 'new_mnemonic.json')
+    msg_mnemonic_presentation = load_text(['msg_mnemonic_presentation'], mnemonic_json_file, 'new_mnemonic')
+    msg_mnemonic_retype_prompt = load_text(['msg_mnemonic_retype_prompt'], mnemonic_json_file, 'new_mnemonic')
+    msg_mnemonic_clipboard_warning = load_text(['msg_mnemonic_clipboard_warning'], mnemonic_json_file, 'new_mnemonic')
 
     seed_phrase = ''
-    encoded_phrase = b''
-    parsing = False
-    mnemonic_json_file = os.path.join(os.getcwd(), 'ethstaker_deposit/../ethstaker_deposit/cli/', 'new_mnemonic.json')
-    msg_mnemonic_clipboard_warning = load_text(['msg_mnemonic_clipboard_warning'], mnemonic_json_file, 'new_mnemonic')
-    async for out in proc.stdout:
-        output = out.decode('utf-8').rstrip()
-        if output.startswith(load_text(['msg_mnemonic_presentation'], mnemonic_json_file, 'new_mnemonic')):
-            parsing = True
-        elif output.startswith(load_text(['msg_mnemonic_retype_prompt'], mnemonic_json_file, 'new_mnemonic')):
-            proc.stdin.write(encoded_phrase)
-            proc.stdin.write(b'\n')
-        elif output.startswith(load_text(['msg_confirm_clipboard_clearing'], mnemonic_json_file, 'new_mnemonic')):
-            proc.stdin.write(b'\n')
-        elif parsing:
+
+    async with InteractiveProcess(' '.join(cmd_args)) as process:
+        await process.expect(msg_mnemonic_presentation)
+
+        # Collect the mnemonic itself, skipping the separator lines and the
+        # clipboard warning printed around it.
+        while True:
+            line = await process.readline()
+            if line is None:
+                raise process.fail('Subprocess exited before asking to retype the mnemonic')
+            if msg_mnemonic_retype_prompt in line:
+                break
             if (
-                not output.startswith('********************')
-                and not output.startswith(msg_mnemonic_clipboard_warning)
+                not line.startswith('********************')
+                and msg_mnemonic_clipboard_warning not in line
             ):
-                seed_phrase += output
-                if len(seed_phrase) > 0:
-                    abbreviated_mnemonic = ' '.join(abbreviate_words(seed_phrase.split(' ')))
-                    encoded_phrase = abbreviated_mnemonic.encode()
-                    parsing = False
+                seed_phrase += line
 
-    assert len(seed_phrase) > 0
-
-    await proc.wait()
+        assert len(seed_phrase.strip()) > 0
+        # The CLI accepts abbreviated words as confirmation of a written down mnemonic.
+        abbreviated_mnemonic = ' '.join(abbreviate_words(seed_phrase.strip().split(' ')))
+        await process.sendline(abbreviated_mnemonic)
+        await process.wait()
 
     # Check files
     validator_keys_folder_path = os.path.join(my_folder_path, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)


### PR DESCRIPTION
**What I did**

The interactive CLI tests were previously brittle with their stdout/stdin interaction. Improve upon it while still testing the actual executable installed by `./deposit.sh install`.

This is a first step and does not address #30 and #237 , those will be handled in a separate PR.

Created with Ox Alpha High.

AI-generated description:

New files
- `tests/test_cli/interactive.py` — InteractiveProcess: expect-style async wrapper with per-read timeouts (`asyncio.wait_for`), overall expect/exit deadlines, ANSI escape stripping, substring matching, stderr merged into stdout, full transcript in failure messages, `returncode == 0` assertion in `wait()`, and kill-on-failure cleanup. Documents the intentional `PYTEST_CURRENT_TEST` passthrough and why the only real interaction is the retype prompt (`click.pause` is a no-op on non-TTY pipes).
- `tests/test_cli/conftest.py` — session-scoped deposit_cli_installed fixture; `./deposit.sh install` now runs once instead of once per test.

Rewritten tests
- `test_script_bls_withdrawal` / `test_script_abbreviated_mnemonic` (`tests/test_cli/test_new_mnemonic.py:874`): expect(msg_mnemonic_presentation) → collect mnemonic lines → sendline(...) → wait(). Dead clipboard-clearing branch removed.
- `test_script / test_script_abbreviated_mnemonic` (`tests/test_cli/test_existing_mnemonic.py`) and `test_exit_transaction_mnemonic_multiple`: use the fixture + InteractiveProcess, gaining `returncode` assertions and failure transcripts they previously lacked.

Verification performed
- Full run of the three test files: 42 passed (~1m45s).
- Helper negative checks (scratch script, since deleted): EOF-before-prompt, silent-child timeout, nonzero exit, interactive send/expect round-trip, ANSI stripping — all fail fast with useful messages instead of hanging. One noted limitation: prompts without a trailing newline aren't visible to line-based reading; irrelevant here since click.prompt always newline-terminates its prompt text.
- No pytest invocation changes were needed; hang protection lives entirely in the helper.

**Related issue**
closes #174 
