### PR TITLE
Dependabot tracks transitive dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
+    allow:
+      - dependency-type: "all"
     cooldown:
       default-days: 7
     directory: "/"


### PR DESCRIPTION
**What I did**

Change `dependabot.yml` to track transitive dependencies

It did not do so before, and these are currently outdated:

Via pre-commit/virtualenv toolchain:
- cfgv 3.4.0 → 3.5.0
- distlib 0.3.9 → 0.4.3
- filelock 3.20.3 → 3.32.4
- identify 2.6.6 → 2.6.19
- nodeenv 1.9.1 → 1.10.0
- platformdirs 4.3.6 → 4.11.3
- pyyaml 6.0.2 → 6.0.3
- virtualenv 20.36.1 → 21.7.4
Via mypy:
- ast-serialize 0.6.0 → 0.8.0
- librt 0.13.0 → 0.15.0

